### PR TITLE
changed VISIBLE macro back to NEAACDECAPI and specify visibility attribute

### DIFF
--- a/include/neaacdec.h
+++ b/include/neaacdec.h
@@ -60,16 +60,11 @@ extern "C" {
 
 #ifdef _WIN32
   #pragma pack(push, 8)
-  #ifndef CDECL
-   #define CDECL __cdecl
-  #endif
-  #define VISIBLE __declspec( dllexport )
+  #define NEAACDECAPI
 #elif defined(__GNUC__) && __GNUC__ >= 4
-  #define CDECL
-  #define VISIBLE __attribute__((visibility("default")))
+  #define NEAACDECAPI __attribute__((visibility("default")))
 #else
-  #define CDECL
-  #define VISIBLE
+  #define NEAACDECAPI
 #endif
 
 #define FAAD2_VERSION "unknown"
@@ -201,57 +196,57 @@ typedef struct NeAACDecFrameInfo
     unsigned char ps;
 } NeAACDecFrameInfo;
 
-VISIBLE char* CDECL NeAACDecGetErrorMessage(unsigned char errcode);
+NEAACDECAPI char* NeAACDecGetErrorMessage(unsigned char errcode);
 
-VISIBLE unsigned long CDECL NeAACDecGetCapabilities(void);
+NEAACDECAPI unsigned long NeAACDecGetCapabilities(void);
 
-VISIBLE NeAACDecHandle CDECL NeAACDecOpen(void);
+NEAACDECAPI NeAACDecHandle NeAACDecOpen(void);
 
-VISIBLE NeAACDecConfigurationPtr CDECL NeAACDecGetCurrentConfiguration(NeAACDecHandle hDecoder);
+NEAACDECAPI NeAACDecConfigurationPtr NeAACDecGetCurrentConfiguration(NeAACDecHandle hDecoder);
 
-VISIBLE unsigned char CDECL NeAACDecSetConfiguration(NeAACDecHandle hDecoder,
+NEAACDECAPI unsigned char NeAACDecSetConfiguration(NeAACDecHandle hDecoder,
                                                    NeAACDecConfigurationPtr config);
 
 /* Init the library based on info from the AAC file (ADTS/ADIF) */
-VISIBLE long CDECL NeAACDecInit(NeAACDecHandle hDecoder,
+NEAACDECAPI long NeAACDecInit(NeAACDecHandle hDecoder,
                               unsigned char *buffer,
                               unsigned long buffer_size,
                               unsigned long *samplerate,
                               unsigned char *channels);
 
 /* Init the library using a DecoderSpecificInfo */
-VISIBLE char CDECL NeAACDecInit2(NeAACDecHandle hDecoder,
+NEAACDECAPI char NeAACDecInit2(NeAACDecHandle hDecoder,
                                unsigned char *pBuffer,
                                unsigned long SizeOfDecoderSpecificInfo,
                                unsigned long *samplerate,
                                unsigned char *channels);
 
 /* Init the library for DRM */
-VISIBLE char CDECL NeAACDecInitDRM(NeAACDecHandle *hDecoder, unsigned long samplerate,
+NEAACDECAPI char NeAACDecInitDRM(NeAACDecHandle *hDecoder, unsigned long samplerate,
                                  unsigned char channels);
 
-VISIBLE void CDECL NeAACDecPostSeekReset(NeAACDecHandle hDecoder, long frame);
+NEAACDECAPI void NeAACDecPostSeekReset(NeAACDecHandle hDecoder, long frame);
 
-VISIBLE void CDECL NeAACDecClose(NeAACDecHandle hDecoder);
+NEAACDECAPI void NeAACDecClose(NeAACDecHandle hDecoder);
 
-VISIBLE void* CDECL NeAACDecDecode(NeAACDecHandle hDecoder,
+NEAACDECAPI void* NeAACDecDecode(NeAACDecHandle hDecoder,
                                  NeAACDecFrameInfo *hInfo,
                                  unsigned char *buffer,
                                  unsigned long buffer_size);
 
-VISIBLE void* CDECL NeAACDecDecode2(NeAACDecHandle hDecoder,
+NEAACDECAPI void* NeAACDecDecode2(NeAACDecHandle hDecoder,
                                   NeAACDecFrameInfo *hInfo,
                                   unsigned char *buffer,
                                   unsigned long buffer_size,
                                   void **sample_buffer,
                                   unsigned long sample_buffer_size);
 
-VISIBLE char CDECL NeAACDecAudioSpecificConfig(unsigned char *pBuffer,
+NEAACDECAPI char NeAACDecAudioSpecificConfig(unsigned char *pBuffer,
                                              unsigned long buffer_size,
                                              mp4AudioSpecificConfig *mp4ASC);
 
 /* Get version and copyright strings */
-VISIBLE int CDECL NeAACDecGetVersion(char **faad_id_string,
+NEAACDECAPI int NeAACDecGetVersion(char **faad_id_string,
                                    char **faad_copyright_string);
 
 #ifdef _WIN32

--- a/libfaad/decoder.c
+++ b/libfaad/decoder.c
@@ -64,7 +64,7 @@ static void create_channel_config(NeAACDecStruct *hDecoder,
                                   NeAACDecFrameInfo *hInfo);
 
 
-VISIBLE int CDECL NeAACDecGetVersion(char **faad_id_string,
+int NeAACDecGetVersion(char **faad_id_string,
                                    char **faad_copyright_string)
 {
     static char *libfaadName = PACKAGE_VERSION;
@@ -81,14 +81,15 @@ VISIBLE int CDECL NeAACDecGetVersion(char **faad_id_string,
 
     return 0;
 }
-VISIBLE char* CDECL NeAACDecGetErrorMessage(unsigned char errcode)
+
+char* NeAACDecGetErrorMessage(unsigned char errcode)
 {
     if (errcode >= NUM_ERROR_MESSAGES)
         return NULL;
     return err_msg[errcode];
 }
 
-VISIBLE unsigned long CDECL NeAACDecGetCapabilities(void)
+unsigned long NeAACDecGetCapabilities(void)
 {
     uint32_t cap = 0;
 
@@ -115,7 +116,7 @@ VISIBLE unsigned long CDECL NeAACDecGetCapabilities(void)
 }
 
 const unsigned char mes[] = { 0x67,0x20,0x61,0x20,0x20,0x20,0x6f,0x20,0x72,0x20,0x65,0x20,0x6e,0x20,0x20,0x20,0x74,0x20,0x68,0x20,0x67,0x20,0x69,0x20,0x72,0x20,0x79,0x20,0x70,0x20,0x6f,0x20,0x63 };
-VISIBLE NeAACDecHandle CDECL NeAACDecOpen(void)
+NeAACDecHandle NeAACDecOpen(void)
 {
     uint8_t i;
     NeAACDecStruct *hDecoder = NULL;
@@ -176,7 +177,7 @@ VISIBLE NeAACDecHandle CDECL NeAACDecOpen(void)
     return hDecoder;
 }
 
-VISIBLE NeAACDecConfigurationPtr CDECL NeAACDecGetCurrentConfiguration(NeAACDecHandle hpDecoder)
+NeAACDecConfigurationPtr NeAACDecGetCurrentConfiguration(NeAACDecHandle hpDecoder)
 {
     NeAACDecStruct* hDecoder = (NeAACDecStruct*)hpDecoder;
     if (hDecoder)
@@ -189,7 +190,7 @@ VISIBLE NeAACDecConfigurationPtr CDECL NeAACDecGetCurrentConfiguration(NeAACDecH
     return NULL;
 }
 
-VISIBLE unsigned char CDECL NeAACDecSetConfiguration(NeAACDecHandle hpDecoder,
+unsigned char NeAACDecSetConfiguration(NeAACDecHandle hpDecoder,
                                                    NeAACDecConfigurationPtr config)
 {
     NeAACDecStruct* hDecoder = (NeAACDecStruct*)hpDecoder;
@@ -252,7 +253,7 @@ static int latmCheck(latm_header *latm, bitfile *ld)
 }
 
 
-VISIBLE long CDECL NeAACDecInit(NeAACDecHandle hpDecoder,
+long NeAACDecInit(NeAACDecHandle hpDecoder,
                               unsigned char *buffer,
                               unsigned long buffer_size,
                               unsigned long *samplerate,
@@ -386,7 +387,7 @@ VISIBLE long CDECL NeAACDecInit(NeAACDecHandle hpDecoder,
 }
 
 /* Init the library using a DecoderSpecificInfo */
-VISIBLE char CDECL NeAACDecInit2(NeAACDecHandle hpDecoder,
+char NeAACDecInit2(NeAACDecHandle hpDecoder,
                                unsigned char *pBuffer,
                                unsigned long SizeOfDecoderSpecificInfo,
                                unsigned long *samplerate,
@@ -480,7 +481,7 @@ VISIBLE char CDECL NeAACDecInit2(NeAACDecHandle hpDecoder,
 }
 
 #ifdef DRM
-VISIBLE char CDECL NeAACDecInitDRM(NeAACDecHandle *hpDecoder,
+char NeAACDecInitDRM(NeAACDecHandle *hpDecoder,
                                  unsigned long samplerate,
                                  unsigned char channels)
 {
@@ -523,7 +524,7 @@ VISIBLE char CDECL NeAACDecInitDRM(NeAACDecHandle *hpDecoder,
 }
 #endif
 
-VISIBLE void CDECL NeAACDecClose(NeAACDecHandle hpDecoder)
+void NeAACDecClose(NeAACDecHandle hpDecoder)
 {
     uint8_t i;
     NeAACDecStruct* hDecoder = (NeAACDecStruct*)hpDecoder;
@@ -577,7 +578,7 @@ VISIBLE void CDECL NeAACDecClose(NeAACDecHandle hpDecoder)
     if (hDecoder) faad_free(hDecoder);
 }
 
-VISIBLE void CDECL NeAACDecPostSeekReset(NeAACDecHandle hpDecoder, long frame)
+void NeAACDecPostSeekReset(NeAACDecHandle hpDecoder, long frame)
 {
     NeAACDecStruct* hDecoder = (NeAACDecStruct*)hpDecoder;
     if (hDecoder)
@@ -807,7 +808,7 @@ static void create_channel_config(NeAACDecStruct *hDecoder, NeAACDecFrameInfo *h
     }
 }
 
-VISIBLE void* CDECL NeAACDecDecode(NeAACDecHandle hpDecoder,
+void* NeAACDecDecode(NeAACDecHandle hpDecoder,
                                  NeAACDecFrameInfo *hInfo,
                                  unsigned char *buffer,
                                  unsigned long buffer_size)
@@ -816,7 +817,7 @@ VISIBLE void* CDECL NeAACDecDecode(NeAACDecHandle hpDecoder,
     return aac_frame_decode(hDecoder, hInfo, buffer, buffer_size, NULL, 0);
 }
 
-VISIBLE void* CDECL NeAACDecDecode2(NeAACDecHandle hpDecoder,
+void* NeAACDecDecode2(NeAACDecHandle hpDecoder,
                                   NeAACDecFrameInfo *hInfo,
                                   unsigned char *buffer,
                                   unsigned long buffer_size,

--- a/libfaad/mp4.c
+++ b/libfaad/mp4.c
@@ -114,7 +114,7 @@ static uint8_t ObjectTypesTable[32] = {
 };
 
 /* Table 1.6.1 */
-VISIBLE char CDECL NeAACDecAudioSpecificConfig(unsigned char *pBuffer,
+char NeAACDecAudioSpecificConfig(unsigned char *pBuffer,
                                              unsigned long buffer_size,
                                              mp4AudioSpecificConfig *mp4ASC)
 {


### PR DESCRIPTION
... for gcc, and nothing for Visual Studio (continuing using the .def file); also removed CDECL, as everything is wrapped in a extern "C" {} scope.

I think these pull request changes nothing for gcc, and correctly exports functions for Visual Studio.