### PR TITLE
Fixed numerous compiler warnings.

### DIFF
--- a/frontend/main.c
+++ b/frontend/main.c
@@ -572,42 +572,43 @@ static int decodeAACfile(char *aacfile, char *sndfile, char *adts_fn, int to_std
 
     /* get AAC infos for printing */
     header_type = 0;
-    if (streaminput == 1 )
-	lookforheader(&b);
+    if (streaminput == 1)
+        lookforheader(&b);
 
     if ((b.buffer[0] == 0xFF) && ((b.buffer[1] & 0xF6) == 0xF0))
     {
-        if (streaminput ==1)
-	{
-	    int frames, frame_length;
-	    int samplerate;
-	    float frames_per_sec, bytes_per_frame;
-	    samplerate = adts_sample_rates[(b.buffer[2]&0x3c)>>2];
-	    frame_length = ((((unsigned int)b.buffer[3] & 0x3)) << 11)
-	        | (((unsigned int)b.buffer[4]) << 3) | (b.buffer[5] >> 5);
+        if (streaminput == 1)
+        {
+            int /*frames,*/ frame_length;
+            int samplerate;
+            float frames_per_sec, bytes_per_frame;
+            channels = 2;
+            samplerate = adts_sample_rates[(b.buffer[2]&0x3c)>>2];
+            frame_length = ((((unsigned int)b.buffer[3] & 0x3)) << 11)
+                | (((unsigned int)b.buffer[4]) << 3) | (b.buffer[5] >> 5);
+            frames_per_sec = (float)samplerate/1024.0f;
+            bytes_per_frame = (float)frame_length/(float)(1000);
+            bitrate = (int)(8. * bytes_per_frame * frames_per_sec + 0.5);
+            length = 1;
+            faad_fprintf(stderr, "Streamed input format  samplerate %d channels %d.\n", samplerate, channels);
+        } else {
+            adts_parse(&b, &bitrate, &length);
+            fseek(b.infile, tagsize, SEEK_SET);
 
-	    frames_per_sec = (float)samplerate/1024.0f;
-	    bytes_per_frame = (float)frame_length/(float)(1000);
-	    bitrate = (int)(8. * bytes_per_frame * frames_per_sec + 0.5);
-	    length = 1;
-	    faad_fprintf(stderr, "Streamed input format  samplerate %d channels %d.\n",samplerate,channels);
-
-	} else {
-		adts_parse(&b, &bitrate, &length);
-        	fseek(b.infile, tagsize, SEEK_SET);
-
-        	bread = fread(b.buffer, 1, FAAD_MIN_STREAMSIZE*MAX_CHANNELS, b.infile);
-        	if (bread != FAAD_MIN_STREAMSIZE*MAX_CHANNELS)
-        	    b.at_eof = 1;
-        	else
-        	    b.at_eof = 0;
-        	b.bytes_into_buffer = bread;
-        	b.bytes_consumed = 0;
-        	b.file_offset = tagsize;
-	}
+            bread = fread(b.buffer, 1, FAAD_MIN_STREAMSIZE*MAX_CHANNELS, b.infile);
+            if (bread != FAAD_MIN_STREAMSIZE*MAX_CHANNELS)
+                b.at_eof = 1;
+            else
+                b.at_eof = 0;
+            b.bytes_into_buffer = bread;
+            b.bytes_consumed = 0;
+            b.file_offset = tagsize;
+        }
 
         header_type = 1;
-    } else if (memcmp(b.buffer, "ADIF", 4) == 0) {
+    }
+    else if (memcmp(b.buffer, "ADIF", 4) == 0)
+    {
         int skip_size = (b.buffer[4] & 0x80) ? 9 : 0;
         bitrate = ((unsigned int)(b.buffer[4 + skip_size] & 0x0F)<<19) |
             ((unsigned int)b.buffer[5 + skip_size]<<11) |
@@ -785,7 +786,7 @@ static int decodeMP4file(char *mp4file, char *sndfile, char *adts_fn, int to_std
                   int outputFormat, int fileType, int downMatrix, int noGapless,
                   int infoOnly, int adts_out, float *song_length, float seek_to)
 {
-    int track;
+    /*int track;*/
     unsigned long samplerate;
     unsigned char channels;
     void *sample_buffer;
@@ -876,7 +877,7 @@ static int decodeMP4file(char *mp4file, char *sndfile, char *adts_fn, int to_std
     faad_fprintf(stderr, "%s file info:\n\n", mp4file);
     {
         char *tag = NULL, *item = NULL;
-        int k, j;
+        /*int k, j;*/
         char *ot[6] = { "NULL", "MAIN AAC", "LC AAC", "SSR AAC", "LTP AAC", "HE AAC" };
         float seconds;
         seconds = (float)mp4config.samples/(float)mp4ASC.samplingFrequency;
@@ -901,7 +902,7 @@ static int decodeMP4file(char *mp4file, char *sndfile, char *adts_fn, int to_std
     mp4read_seek(startSampleId);
     for (sampleId = startSampleId; sampleId < mp4config.frame.ents; sampleId++)
     {
-        int rc;
+        /*int rc;*/
         long dur;
         unsigned int sample_count;
         unsigned int delay = 0;

--- a/frontend/main.c
+++ b/frontend/main.c
@@ -86,10 +86,10 @@ static void faad_fprintf(FILE *stream, const char *fmt, ...)
     }
 
 #ifdef _WIN32
-	if (!_isatty(_fileno(stream)))
-	{
-		fflush(stream); /*ensure real-time progress output on Win32*/
-	}
+    if (!_isatty(_fileno(stream)))
+    {
+        fflush(stream); /*ensure real-time progress output on Win32*/
+    }
 #endif
 }
 
@@ -153,41 +153,43 @@ static void advance_buffer(aac_buffer *b, int bytes)
 {
     while ((b->bytes_into_buffer > 0) && (bytes > 0))
     {
-	int chunk = min(bytes, b->bytes_into_buffer);
-	
-	bytes -= chunk;
-	b->file_offset += chunk;
-	b->bytes_consumed = chunk;
-	b->bytes_into_buffer -= chunk;
+        int chunk = min(bytes, b->bytes_into_buffer);
+    
+        bytes -= chunk;
+        b->file_offset += chunk;
+        b->bytes_consumed = chunk;
+        b->bytes_into_buffer -= chunk;
 
-	if (b->bytes_into_buffer == 0)
-	    fill_buffer(b);
+        if (b->bytes_into_buffer == 0)
+            fill_buffer(b);
     }
 }
 
 static void lookforheader(aac_buffer *b)
 {
-  int i = 0;
-	while (!b->at_eof )
-	{
-       		if (b->bytes_into_buffer > 4)
-        	{
-		    if( ((b->buffer[0+i] == 0xff) && ((b->buffer[1+i] & 0xf6) == 0xf0)) ||
-       			 (b->buffer[0+i] == 'A'    && b->buffer[1+i] == 'D' && b->buffer[2+i] == 'I' && b->buffer[3+i] == 'F'))
-			{
-				fill_buffer(b);
-				break;
-			} else {
-				i++;
-    				b->file_offset       += 1;
-    				b->bytes_consumed    += 1;
-    				b->bytes_into_buffer -= 1;
-			}
-		} else {
-			fill_buffer(b);
-			i = 0;
-		}
-	}
+    int i = 0;
+    while (!b->at_eof )
+    {
+        if (b->bytes_into_buffer > 4)
+        {
+            if( ((b->buffer[0+i] == 0xff) && ((b->buffer[1+i] & 0xf6) == 0xf0)) ||
+                (b->buffer[0+i] == 'A'    && b->buffer[1+i] == 'D' && b->buffer[2+i] == 'I' && b->buffer[3+i] == 'F'))
+            {
+                fill_buffer(b);
+                break;
+            } else {
+                i++;
+                b->file_offset       += 1;
+                b->bytes_consumed    += 1;
+                b->bytes_into_buffer -= 1;
+            }
+        }
+        else
+        {
+            fill_buffer(b);
+            i = 0;
+        }
+    }
 }
 
 static int adts_sample_rates[] = {96000,88200,64000,48000,44100,32000,24000,22050,16000,12000,11025,8000,7350,0,0,0};
@@ -497,36 +499,37 @@ static int decodeAACfile(char *aacfile, char *sndfile, char *adts_fn, int to_std
 
     if (0 == strcmp(aacfile, "-"))
     {
-	b.infile = stdin;
+        b.infile = stdin;
 #ifdef _WIN32
         _setmode(_fileno(stdin), O_BINARY);
 #endif
 
-    } else
+    }
+    else
     {
-    	b.infile = faad_fopen(aacfile, "rb");
-    	if (b.infile == NULL)
-    	{
-    	    /* unable to open file */
-    	    faad_fprintf(stderr, "Error opening file: %s\n", aacfile);
-    	    return 1;
-    	}
+        b.infile = faad_fopen(aacfile, "rb");
+        if (b.infile == NULL)
+        {
+            /* unable to open file */
+            faad_fprintf(stderr, "Error opening file: %s\n", aacfile);
+            return 1;
+        }
     }
 
     retval = fseek(b.infile, 0, SEEK_END);
 #ifdef _WIN32
-	if (0 == strcmp(aacfile, "-")) {
-	  retval = -1;
-	}
+    if (0 == strcmp(aacfile, "-")) {
+        retval = -1;
+    }
 #endif
     if (retval )
     {
-	 faad_fprintf(stderr, "Input not seekable %s\n", aacfile);
-	 fileread = -1;
-         streaminput = 1;
+        faad_fprintf(stderr, "Input not seekable %s\n", aacfile);
+        fileread = -1;
+        streaminput = 1;
     } else {
-    	fileread = ftell(b.infile);
-    	fseek(b.infile, 0, SEEK_SET);
+        fileread = ftell(b.infile);
+        fseek(b.infile, 0, SEEK_SET);
     };
 
     if (!(b.buffer = (unsigned char*)malloc(FAAD_MIN_STREAMSIZE*MAX_CHANNELS)))
@@ -747,7 +750,7 @@ static int decodeAACfile(char *aacfile, char *sndfile, char *adts_fn, int to_std
         {
             if (write_audio_file(aufile, sample_buffer, frameInfo.samples, 0) == 0)
                 break;
-		}
+        }
 
         /* fill buffer */
         fill_buffer(&b);
@@ -1171,7 +1174,7 @@ static int faad_main(int argc, char *argv[])
         case 'j':
             if (optarg)
             {
-            	seekTo = atof(optarg);
+                seekTo = atof(optarg);
             }
             break;
         case 't':
@@ -1270,22 +1273,22 @@ static int faad_main(int argc, char *argv[])
 
     /* check for mp4 file */
     if (0 == strcmp(aacFileName, "-")) {
-   	faad_fprintf(stderr, "Reading from stdin: %s\n", aacFileName);
-	readFromStdin = 1;
-	hMP4File  = stdin;
+        faad_fprintf(stderr, "Reading from stdin: %s\n", aacFileName);
+        readFromStdin = 1;
+        hMP4File  = stdin;
 #ifdef _WIN32
         _setmode(_fileno(stdin), O_BINARY);
 #endif
 
     } else {
 
-    	mp4file = 0;
-    	hMP4File = faad_fopen(aacFileName, "rb");
-    	if (!hMP4File)
-    	{
-    	    faad_fprintf(stderr, "Error opening file: %s\n", aacFileName);
-    	    return 1;
-    	}
+        mp4file = 0;
+        hMP4File = faad_fopen(aacFileName, "rb");
+        if (!hMP4File)
+        {
+            faad_fprintf(stderr, "Error opening file: %s\n", aacFileName);
+            return 1;
+        }
     }
 
     fread(header, 1, 8, hMP4File);
@@ -1297,7 +1300,7 @@ static int faad_main(int argc, char *argv[])
         mp4file = 1;
 
     if (!mp4file && seekTo != 0) {
-    	faad_fprintf(stderr, "Warning: can only seek in MP4 files");
+        faad_fprintf(stderr, "Warning: can only seek in MP4 files");
     }
 
     if (mp4file)
@@ -1306,16 +1309,16 @@ static int faad_main(int argc, char *argv[])
             outputFormat, format, downMatrix, noGapless, infoOnly, adts_out, &length, seekTo);
     } else {
 
-	if (readFromStdin == 1) {
-		ungetc(header[7],hMP4File);
-		ungetc(header[6],hMP4File);
-		ungetc(header[5],hMP4File);
-		ungetc(header[4],hMP4File);
-		ungetc(header[3],hMP4File);
-		ungetc(header[2],hMP4File);
-		ungetc(header[1],hMP4File);
-		ungetc(header[0],hMP4File);
-	}
+    if (readFromStdin == 1) {
+        ungetc(header[7],hMP4File);
+        ungetc(header[6],hMP4File);
+        ungetc(header[5],hMP4File);
+        ungetc(header[4],hMP4File);
+        ungetc(header[3],hMP4File);
+        ungetc(header[2],hMP4File);
+        ungetc(header[1],hMP4File);
+        ungetc(header[0],hMP4File);
+    }
 
         result = decodeAACfile(aacFileName, audioFileName, adtsFileName, writeToStdio,
             def_srate, object_type, outputFormat, format, downMatrix, infoOnly, adts_out,
@@ -1351,15 +1354,15 @@ static int faad_main(int argc, char *argv[])
 int main(int argc, char *argv[])
 {
 #if defined WIN32 || defined _WIN32 || defined WIN64 || defined _WIN64
-	int argc_utf8, exit_code;
-	char **argv_utf8;
-	init_console_utf8(stderr);
-	init_commandline_arguments_utf8(&argc_utf8, &argv_utf8);
-	exit_code = faad_main(argc_utf8, argv_utf8);
-	free_commandline_arguments_utf8(&argc_utf8, &argv_utf8);
-	uninit_console_utf8();
-	return exit_code;
+    int argc_utf8, exit_code;
+    char **argv_utf8;
+    init_console_utf8(stderr);
+    init_commandline_arguments_utf8(&argc_utf8, &argv_utf8);
+    exit_code = faad_main(argc_utf8, argv_utf8);
+    free_commandline_arguments_utf8(&argc_utf8, &argv_utf8);
+    uninit_console_utf8();
+    return exit_code;
 #else
-	return faad_main(argc, argv);
+    return faad_main(argc, argv);
 #endif
 }

--- a/libfaad/hcr.c
+++ b/libfaad/hcr.c
@@ -225,7 +225,7 @@ uint8_t reordered_spectral_data(NeAACDecStruct *hDecoder, ic_stream *ics,
 
     uint16_t sp_offset[8];
     uint16_t g, i, sortloop, set, bitsread;
-    uint16_t bitsleft, codewordsleft;
+    /*uint16_t bitsleft, codewordsleft*/;
     uint8_t w_idx, sfb, this_CB, last_CB, this_sec_CB; 
     
     const uint16_t nshort = hDecoder->frameLength/8;

--- a/libfaad/pns.c
+++ b/libfaad/pns.c
@@ -241,7 +241,7 @@ void pns_decode(ic_stream *ics_left, ic_stream *ics_right,
                         (ics_left->ms_used[g][sfb])) ||
                         (ics_left->ms_mask_present == 2)))
                     {
-                        uint16_t c;
+                        /*uint16_t c;*/
 
                         offs = ics_right->swb_offset[sfb];
                         size = min(ics_right->swb_offset[sfb+1], ics_right->swb_offset_max) - offs;


### PR DESCRIPTION
Mostly fixes warnings about unused or un-initialized variables.

Also fixed (incompatible) re-definition of an STDC function in **`getopt.c`** on Win32.

**Note:** In function `decodeAACfile()`, the variable `channels` was ***undefined*** in one of the **IF** blocks. I initialized it to **zero** as a workaround. Requires deeper investigation though...
