### PR TITLE
bswap fix + MSVC solution clean-up

### DIFF
--- a/frontend/mp4read.c
+++ b/frontend/mp4read.c
@@ -49,28 +49,30 @@ static FILE *g_fin = NULL;
 static inline uint32_t bswap32(const uint32_t u32)
 {
 #ifndef WORDS_BIGENDIAN
-#ifdef _MSC_VER
-	return _byteswap_ulong(u32);
-#else
+#if defined (__GNUC__) && ((__GNUC__ > 4) || ((__GNUC__ == 4) && (__GNUC_MINOR__ >= 3)))
     return __builtin_bswap32(u32);
+#elif defined (_MSC_VER)
+    return _byteswap_ulong(u32);
+#else
+    return (u32 << 24) | ((u32 << 8) & 0xFF0000) | ((u32 >> 8) & 0xFF00) | (u32 >> 24);
 #endif
 #else
-	return u32;
+    return u32;
 #endif
 }
 
 static inline uint16_t bswap16(const uint16_t u16)
 {
 #ifndef WORDS_BIGENDIAN
-#ifdef _MSC_VER
-	return _byteswap_ushort(u16);
-#elif __GNUC__ > 4 || (__GNUC__ == 4 && __GNUC_MINOR__ >= 8)
-	return __builtin_bswap16(u16);
+#if defined (__GNUC__) && ((__GNUC__ > 4) || ((__GNUC__ == 4) && (__GNUC_MINOR__ >= 8)))
+    return __builtin_bswap16(u16);
+#elif defined (_MSC_VER)
+    return _byteswap_ushort(u16);
 #else
-	return (u16<<8)|(u16>>8);
+    return (u16 << 8) | (u16 >> 8);
 #endif
 #else
-	return u16;
+    return u16;
 #endif
 }
 

--- a/project/msvc/faad2.sln
+++ b/project/msvc/faad2.sln
@@ -1,9 +1,7 @@
 Microsoft Visual Studio Solution File, Format Version 12.00
 # Visual Studio 15
-VisualStudioVersion = 15.0.26730.12
+VisualStudioVersion = 15.0.27130.2010
 MinimumVisualStudioVersion = 10.0.40219.1
-Project("{8BC9CEB8-8B4A-11D0-8D11-00A0C91BC942}") = "aacinfo", "aacinfo.vcxproj", "{FE985E4D-79DB-4DD3-BFED-824B4677A161}"
-EndProject
 Project("{8BC9CEB8-8B4A-11D0-8D11-00A0C91BC942}") = "libfaad", "libfaad.vcxproj", "{BC3EFE27-9015-4C9C-AD3C-72B3B7ED2114}"
 EndProject
 Project("{8BC9CEB8-8B4A-11D0-8D11-00A0C91BC942}") = "libfaad2_dll", "libfaad2_dll.vcxproj", "{482DA264-EE88-4575-B208-87C4CB80CD08}"
@@ -16,10 +14,6 @@ Global
 		Release|Win32 = Release|Win32
 	EndGlobalSection
 	GlobalSection(ProjectConfigurationPlatforms) = postSolution
-		{FE985E4D-79DB-4DD3-BFED-824B4677A161}.Debug|Win32.ActiveCfg = Debug|Win32
-		{FE985E4D-79DB-4DD3-BFED-824B4677A161}.Debug|Win32.Build.0 = Debug|Win32
-		{FE985E4D-79DB-4DD3-BFED-824B4677A161}.Release|Win32.ActiveCfg = Release|Win32
-		{FE985E4D-79DB-4DD3-BFED-824B4677A161}.Release|Win32.Build.0 = Release|Win32
 		{BC3EFE27-9015-4C9C-AD3C-72B3B7ED2114}.Debug|Win32.ActiveCfg = Debug|Win32
 		{BC3EFE27-9015-4C9C-AD3C-72B3B7ED2114}.Debug|Win32.Build.0 = Debug|Win32
 		{BC3EFE27-9015-4C9C-AD3C-72B3B7ED2114}.Release|Win32.ActiveCfg = Release|Win32


### PR DESCRIPTION
- More generalized solution that also fixes compilation with GCC < 4.7.3. 
- Removed non-existing MSVC project from the solution file. 