### PR TITLE
CVE-2018-20194 / CVE-2018-20362 fixes

### DIFF
--- a/libfaad/sbr_hfadj.c
+++ b/libfaad/sbr_hfadj.c
@@ -485,6 +485,12 @@ static void calculate_gain(sbr_info *sbr, sbr_hfadj_info *adj, uint8_t ch)
             ml1 = sbr->f_table_lim[sbr->bs_limiter_bands][k];
             ml2 = sbr->f_table_lim[sbr->bs_limiter_bands][k+1];
 
+            if (ml1 > MAX_M)
+                ml1 = MAX_M;
+
+            if (ml2 > MAX_M)
+                ml2 = MAX_M;
+
 
             /* calculate the accumulated E_orig and E_curr over the limiter band */
             for (m = ml1; m < ml2; m++)
@@ -949,6 +955,12 @@ static void calculate_gain(sbr_info *sbr, sbr_hfadj_info *adj, uint8_t ch)
             ml1 = sbr->f_table_lim[sbr->bs_limiter_bands][k];
             ml2 = sbr->f_table_lim[sbr->bs_limiter_bands][k+1];
 
+            if (ml1 > MAX_M)
+                ml1 = MAX_M;
+
+            if (ml2 > MAX_M)
+                ml2 = MAX_M;
+
 
             /* calculate the accumulated E_orig and E_curr over the limiter band */
             for (m = ml1; m < ml2; m++)
@@ -1192,6 +1204,12 @@ static void calculate_gain(sbr_info *sbr, sbr_hfadj_info *adj, uint8_t ch)
 
             ml1 = sbr->f_table_lim[sbr->bs_limiter_bands][k];
             ml2 = sbr->f_table_lim[sbr->bs_limiter_bands][k+1];
+
+            if (ml1 > MAX_M)
+                ml1 = MAX_M;
+
+            if (ml2 > MAX_M)
+                ml2 = MAX_M;
 
 
             /* calculate the accumulated E_orig and E_curr over the limiter band */

--- a/libfaad/syntax.c
+++ b/libfaad/syntax.c
@@ -344,6 +344,12 @@ static void decode_sce_lfe(NeAACDecStruct *hDecoder,
        can become 2 when some form of Parametric Stereo coding is used
     */
 
+    if (hDecoder->frame && hDecoder->element_id[hDecoder->fr_ch_ele] != id_syn_ele) {
+        /* element inconsistency */
+        hInfo->error = 21;
+        return;
+    }
+
     /* save the syntax element id */
     hDecoder->element_id[hDecoder->fr_ch_ele] = id_syn_ele;
 
@@ -390,6 +396,12 @@ static void decode_cpe(NeAACDecStruct *hDecoder, NeAACDecFrameInfo *hInfo, bitfi
         /* element_output_channels not set yet */
         hDecoder->element_output_channels[hDecoder->fr_ch_ele] = 2;
     } else if (hDecoder->element_output_channels[hDecoder->fr_ch_ele] != 2) {
+        /* element inconsistency */
+        hInfo->error = 21;
+        return;
+    }
+
+    if (hDecoder->frame && hDecoder->element_id[hDecoder->fr_ch_ele] != id_syn_ele) {
         /* element inconsistency */
         hInfo->error = 21;
         return;


### PR DESCRIPTION
**Issue summary:**

The faad2 code base appears to assume that all frames of a same AAC file share the same syntax element structure. However, input files are not strictly verified again this assumption, or too late during file processing.

This leads to security vulnerabilities when processing crafted AAC files where these assumptions are false. For example, files declaring two frames, the first SCE+FIL and the second CPE.

**Patch summary:**

Add checks to decode_sce_lfe and decode_cpe to make sure inter-frame inconsistencies are detected as early as possible.

These checks first read hDecoder->frame: if this is not the first frame then we make sure that the syntax element at the same position in the previous frame also had element_id id_syn_ele. If not, return 21 as this is a fatal file structure issue.

**Issues addressed:**

This patch addresses CVE-2018-20362 (fixes #26) and possibly other related issues.