### PR TITLE
mp4read/sbr_fbt: security bug fixes

### DIFF
--- a/frontend/main.c
+++ b/frontend/main.c
@@ -915,6 +915,11 @@ static int decodeMP4file(char *mp4file, char *sndfile, char *adts_fn, int to_std
 
         sample_buffer = NeAACDecDecode(hDecoder, &frameInfo, mp4config.bitbuf.data, mp4config.bitbuf.size);
 
+        if (!sample_buffer) {
+            /* unable to decode file, abort */
+            break;
+        }
+
         if (adts_out == 1)
         {
             adtsData = MakeAdtsHeader(&adtsDataSize, &frameInfo, 0);

--- a/libfaad/sbr_fbt.c
+++ b/libfaad/sbr_fbt.c
@@ -526,6 +526,8 @@ uint8_t derived_frequency_table(sbr_info *sbr, uint8_t bs_xover_band,
     }
 
     sbr->M = sbr->f_table_res[HI_RES][sbr->N_high] - sbr->f_table_res[HI_RES][0];
+    if (sbr->M > MAX_M)
+        return 1;
     sbr->kx = sbr->f_table_res[HI_RES][0];
     if (sbr->kx > 32)
         return 1;

--- a/libfaad/sbr_syntax.c
+++ b/libfaad/sbr_syntax.c
@@ -196,7 +196,7 @@ uint8_t sbr_extension_data(bitfile *ld, sbr_info *sbr, uint16_t cnt,
             /* if an error occured with the new header values revert to the old ones */
             if (rt > 0)
             {
-                calc_sbr_tables(sbr, saved_start_freq, saved_stop_freq,
+                result += calc_sbr_tables(sbr, saved_start_freq, saved_stop_freq,
                     saved_samplerate_mode, saved_freq_scale,
                     saved_alter_scale, saved_xover_band);
             }
@@ -215,7 +215,7 @@ uint8_t sbr_extension_data(bitfile *ld, sbr_info *sbr, uint16_t cnt,
             if ((result > 0) &&
                 (sbr->Reset || (sbr->bs_header_flag && sbr->just_seeked)))
             {
-                calc_sbr_tables(sbr, saved_start_freq, saved_stop_freq,
+                result += calc_sbr_tables(sbr, saved_start_freq, saved_stop_freq,
                     saved_samplerate_mode, saved_freq_scale,
                     saved_alter_scale, saved_xover_band);          
             }


### PR DESCRIPTION
This PR bundles security bug fixes for CVE-2018-20196 as well as other issues without CVE identifier.

The moovin and decodeMP4file are non-trivial fixes and I highly recommend to test and carefully review these changes before thinking of merging them. I plan to give them a second check next month.

Thanks!