### PR TITLE
specrec: better handle unexpected PS (CVE-2018-20360/CVE-2018-20199)

### DIFF
--- a/libfaad/ps_dec.c
+++ b/libfaad/ps_dec.c
@@ -1508,6 +1508,20 @@ static void ps_mix_phase(ps_info *ps, qmf_t X_left[38][64], qmf_t X_right[38][64
 
                 //printf("%d\n", ps->iid_index[env][bk]);
 
+                /* index range is supposed to be -7...7 or -15...15 depending on iid_mode
+                   (Table 8.24, ISO/IEC 14496-3:2005).
+                   if it is outside these boundaries, this is most likely an error. sanitize
+                   it and try to process further. */
+                if (ps->iid_index[env][bk] < -no_iid_steps) {
+                    fprintf(stderr, "Warning: invalid iid_index: %d < %d\n", ps->iid_index[env][bk],
+                        -no_iid_steps);
+                    ps->iid_index[env][bk] = -no_iid_steps;
+                } else if (ps->iid_index[env][bk] > no_iid_steps) {
+                    fprintf(stderr, "Warning: invalid iid_index: %d > %d\n", ps->iid_index[env][bk],
+                        no_iid_steps);
+                    ps->iid_index[env][bk] = no_iid_steps;
+                }
+
                 /* calculate the scalefactors c_1 and c_2 from the intensity differences */
                 c_1 = sf_iid[no_iid_steps + ps->iid_index[env][bk]];
                 c_2 = sf_iid[no_iid_steps - ps->iid_index[env][bk]];

--- a/libfaad/specrec.c
+++ b/libfaad/specrec.c
@@ -915,18 +915,18 @@ uint8_t reconstruct_single_channel(NeAACDecStruct *hDecoder, ic_stream *ics,
         /* element_output_channels not set yet */
         hDecoder->element_output_channels[hDecoder->fr_ch_ele] = output_channels;
     } else if (hDecoder->element_output_channels[hDecoder->fr_ch_ele] != output_channels) {
-        /* element inconsistency */
-
-        /* this only happens if PS is actually found but not in the first frame
+        /* element inconsistency
+         * this only happens if PS is actually found but not in the first frame
          * this means that there is only 1 bitstream element!
          */
 
-        /* reset the allocation */
-        hDecoder->element_alloced[hDecoder->fr_ch_ele] = 0;
-
-        hDecoder->element_output_channels[hDecoder->fr_ch_ele] = output_channels;
-
-        //return 21;
+        if (hDecoder->fr_channels == 1) {
+            /* reset the allocation */
+            hDecoder->element_alloced[hDecoder->fr_ch_ele] = 0;
+            hDecoder->element_output_channels[hDecoder->fr_ch_ele] = output_channels;
+        } else {
+            return 21;
+        }
     }
 
     if (hDecoder->element_alloced[hDecoder->fr_ch_ele] == 0)


### PR DESCRIPTION
Parametric Stereo (PS) can arrive at any moment in input files. PS changes the number of output channels and therefore requires more allocated memory in various structures from hDecoder.

The current faad2 code attempts to perform allocation surgery in hDecoder to recover from this. This works well when there is only one frame channel, else it creates large number of memory corruption issues.

If there is more than one input channel, return cleanly with error code. It would be nice to handle this, but this is likely to be a lot of work and is beyond the scope of a security fix.

This commit addresses CVE-2018-20360 and CVE-2018-20199 (fixes #32, fixes #24).