### PR TITLE
fix compilation with LC_ONLY_DECODER

### DIFF
--- a/libfaad/Makefile.am
+++ b/libfaad/Makefile.am
@@ -32,5 +32,5 @@ libfaad_la_SOURCES = bits.c cfft.c decoder.c drc.c \
 
 libfaad_drm_la_LDFLAGS = ${libfaad_la_LDFLAGS}
 libfaad_drm_la_LIBADD = ${libfaad_la_LIBADD}
-libfaad_drm_la_CFLAGS = ${libfaad_la_CFLAGS} -DDRM -DDRM_PS
+libfaad_drm_la_CFLAGS = ${libfaad_la_CFLAGS} -DDRM_SUPPORT
 libfaad_drm_la_SOURCES = ${libfaad_la_SOURCES}

--- a/libfaad/common.h
+++ b/libfaad/common.h
@@ -91,8 +91,10 @@ extern "C" {
 /* Allow decoding of LD profile AAC */
 #define LD_DEC
 /* Allow decoding of Digital Radio Mondiale (DRM) */
-//#define DRM
-//#define DRM_PS
+#ifdef DRM_SUPPORT
+#define DRM
+#define DRM_PS
+#endif
 
 /* LD can't do without LTP */
 #ifdef LD_DEC
@@ -115,6 +117,7 @@ extern "C" {
   #undef MAIN_DEC
   #undef SSR_DEC
   #undef DRM
+  #undef DRM_PS
   #undef ALLOW_SMALL_FRAMELENGTH
   #undef ERROR_RESILIENCE
 #endif


### PR DESCRIPTION
881b5e263f25a8a8b714e83407fc2c9dab407e40 broke compilation by always
defining DRN and DRM_PS. Fix this and place the define where it belongs.