### PR TITLE
fix compilation without SBR/PS_DEC

### DIFF
--- a/libfaad/mp4.c
+++ b/libfaad/mp4.c
@@ -33,7 +33,6 @@
 
 #include <stdlib.h>
 
-#include "bits.h"
 #include "mp4.h"
 #include "syntax.h"
 

--- a/libfaad/mp4.h
+++ b/libfaad/mp4.h
@@ -35,6 +35,7 @@
 extern "C" {
 #endif
 
+#include "bits.h"
 #include "neaacdec.h"
 
 int8_t AudioSpecificConfig2(uint8_t *pBuffer,


### PR DESCRIPTION
The bits.h include needs to be in mp4.h as it uses the bitfield struct.