### PR TITLE
Initialize element_id array with an invalid id.

### DIFF
--- a/libfaad/decoder.c
+++ b/libfaad/decoder.c
@@ -153,6 +153,7 @@ NeAACDecHandle NeAACDecOpen(void)
 
     for (i = 0; i < MAX_CHANNELS; i++)
     {
+        hDecoder->element_id[i] = INVALID_ELEMENT_ID;
         hDecoder->window_shape_prev[i] = 0;
         hDecoder->time_out[i] = NULL;
         hDecoder->fb_intermed[i] = NULL;

--- a/libfaad/syntax.c
+++ b/libfaad/syntax.c
@@ -344,7 +344,9 @@ static void decode_sce_lfe(NeAACDecStruct *hDecoder,
        can become 2 when some form of Parametric Stereo coding is used
     */
 
-    if (hDecoder->frame && hDecoder->element_id[hDecoder->fr_ch_ele] != id_syn_ele) {
+    if (hDecoder->element_id[hDecoder->fr_ch_ele] != INVALID_ELEMENT_ID &&
+        hDecoder->element_id[hDecoder->fr_ch_ele] != id_syn_ele)
+    {
         /* element inconsistency */
         hInfo->error = 21;
         return;
@@ -401,7 +403,9 @@ static void decode_cpe(NeAACDecStruct *hDecoder, NeAACDecFrameInfo *hInfo, bitfi
         return;
     }
 
-    if (hDecoder->frame && hDecoder->element_id[hDecoder->fr_ch_ele] != id_syn_ele) {
+    if (hDecoder->element_id[hDecoder->fr_ch_ele] != INVALID_ELEMENT_ID &&
+        hDecoder->element_id[hDecoder->fr_ch_ele] != id_syn_ele)
+    {
         /* element inconsistency */
         hInfo->error = 21;
         return;

--- a/libfaad/syntax.h
+++ b/libfaad/syntax.h
@@ -91,6 +91,7 @@ extern "C" {
 #define ID_PCE 0x5
 #define ID_FIL 0x6
 #define ID_END 0x7
+#define INVALID_ELEMENT_ID 255
 
 #define ONLY_LONG_SEQUENCE   0x0
 #define LONG_START_SEQUENCE  0x1


### PR DESCRIPTION
Zero is a valid element id so use 255 instead. Use it as a marker to detect if
a channel is already initialized instead of hDecoder->frame.

Fixes regression introduced in 466b01d.