### PR TITLE
main.c: aacFileName is always != NULL

### DIFF
--- a/frontend/main.c
+++ b/frontend/main.c
@@ -1366,9 +1366,7 @@ static int faad_main(int argc, char *argv[])
             dec_length, (dec_length > 0.01) ? (length/dec_length) : 0.);
     }
 
-    if (aacFileName != NULL)
-      free (aacFileName);
-
+    free (aacFileName);
     return 0;
 }
 


### PR DESCRIPTION
And BTW, free() always allows for NULL too.