### PR TITLE
Initialize bit-reader if it is going to be used

### DIFF
--- a/libfaad/bits.c
+++ b/libfaad/bits.c
@@ -42,9 +42,6 @@ void faad_initbits(bitfile *ld, const void *_buffer, const uint32_t buffer_size)
     if (ld == NULL)
         return;
 
-    // useless
-    //memset(ld, 0, sizeof(bitfile));
-
     if (buffer_size == 0 || _buffer == NULL)
     {
         ld->error = 1;

--- a/libfaad/decoder.c
+++ b/libfaad/decoder.c
@@ -923,6 +923,8 @@ static void* aac_frame_decode(NeAACDecStruct *hDecoder,
 
     /* initialize the bitstream */
     faad_initbits(&ld, buffer, buffer_size);
+    if (ld.error != 0)
+        return NULL;
 
 #if 0
     {

--- a/libfaad/mp4.c
+++ b/libfaad/mp4.c
@@ -305,7 +305,8 @@ int8_t AudioSpecificConfig2(uint8_t *pBuffer,
     uint8_t ret = 0;
     bitfile ld;
     faad_initbits(&ld, pBuffer, buffer_size);
-    faad_byte_align(&ld);
+    if (ld.error != 0)
+        return -7;
     ret = AudioSpecificConfigFromBitfile(&ld, mp4ASC, pce, buffer_size, short_form);
     faad_endbits(&ld);
     return ret;

--- a/libfaad/rvlc.c
+++ b/libfaad/rvlc.c
@@ -134,6 +134,8 @@ uint8_t rvlc_decode_scale_factors(ic_stream *ics, bitfile *ld)
 //        faad_initbits_rev(&ld_rvlc_sf_rev, (void*)rvlc_sf_buffer,
 //            ics->length_of_rvlc_sf);
     }
+    if ((ics->length_of_rvlc_sf == 0) || (ld_rvlc_sf.error != 0))
+        memset(&ld_rvlc_sf, 0, sizeof(ld_rvlc_sf));
 
     if (ics->sf_escapes_present)
     {
@@ -147,6 +149,8 @@ uint8_t rvlc_decode_scale_factors(ic_stream *ics, bitfile *ld)
 //        faad_initbits_rev(&ld_rvlc_esc_rev, (void*)rvlc_esc_buffer,
 //            ics->length_of_rvlc_escapes);
     }
+    if (!ics->sf_escapes_present || (ld_rvlc_esc.error != 0))
+        memset(&ld_rvlc_esc, 0, sizeof(ld_rvlc_esc));
 
     /* decode the rvlc scale factors and escapes */
     result = rvlc_decode_sf_forward(ics, &ld_rvlc_sf,


### PR DESCRIPTION
And to not ignore its "error" field after initialization.

If either buffer pointer is null or buffer_size is zero, then bit-reader skips its field initialization.

Bit-reader in such state should not be used.

Added checks for bit reader "error" field.

In `rvlc_decode_scale_factors` logic says that bit-reader should be used anyways, so added zero-initialization there.