### PR TITLE
Check scale_factors uniformly

### DIFF
--- a/libfaad/rvlc.c
+++ b/libfaad/rvlc.c
@@ -208,6 +208,8 @@ static uint8_t rvlc_decode_sf_forward(ic_stream *ics, bitfile *ld_sf, bitfile *l
                     t = rvlc_huffman_sf(ld_sf, ld_esc, +1);
 
                     is_position += t;
+                    if (is_position < 0 || is_position > 255)
+                        return 4;
                     ics->scale_factors[g][sfb] = is_position;
 
                     break;
@@ -224,6 +226,8 @@ static uint8_t rvlc_decode_sf_forward(ic_stream *ics, bitfile *ld_sf, bitfile *l
                         noise_energy += t;
                     }
 
+                    if (is_position < 0 || is_position > 255)
+                        return 4;
                     ics->scale_factors[g][sfb] = noise_energy;
 
                     break;

--- a/libfaad/syntax.c
+++ b/libfaad/syntax.c
@@ -1903,6 +1903,8 @@ static uint8_t decode_scale_factors(ic_stream *ics, bitfile *ld)
                 /* decode intensity position */
                 t = huffman_scale_factor(ld);
                 is_position += (t - 60);
+                if (is_position < 0 || is_position > 255)
+                    return 4;
                 ics->scale_factors[g][sfb] = is_position;
 #ifdef SF_PRINT
                 printf("%d\n", ics->scale_factors[g][sfb]);
@@ -1923,6 +1925,8 @@ static uint8_t decode_scale_factors(ic_stream *ics, bitfile *ld)
                     t -= 60;
                 }
                 noise_energy += t;
+                if (noise_energy < 0 || noise_energy > 255)
+                    return 4;
                 ics->scale_factors[g][sfb] = noise_energy;
 #ifdef SF_PRINT
                 printf("%d\n", ics->scale_factors[g][sfb]);


### PR DESCRIPTION
<0 check is important: values less than -511 result in "Inf" value after exponentiation
>255 is for meeting expectations

Later "Inf" turns to "NaN" and then it is converted to int and used as index -> access-out-of-bounds.