### PR TITLE
Cleanup / typo fixes

### DIFF
--- a/libfaad/decoder.c
+++ b/libfaad/decoder.c
@@ -867,7 +867,7 @@ static void* aac_frame_decode(NeAACDecStruct *hDecoder,
     uint16_t i;
     uint8_t channels = 0;
     uint8_t output_channels = 0;
-    bitfile ld = {0};
+    bitfile ld;
     uint32_t bitsconsumed;
     uint16_t frame_len;
     void *sample_buffer;

--- a/libfaad/rvlc.c
+++ b/libfaad/rvlc.c
@@ -226,7 +226,7 @@ static uint8_t rvlc_decode_sf_forward(ic_stream *ics, bitfile *ld_sf, bitfile *l
                         noise_energy += t;
                     }
 
-                    if (is_position < 0 || is_position > 255)
+                    if (noise_energy < 0 || noise_energy > 255)
                         return 4;
                     ics->scale_factors[g][sfb] = noise_energy;
 
@@ -237,7 +237,7 @@ static uint8_t rvlc_decode_sf_forward(ic_stream *ics, bitfile *ld_sf, bitfile *l
                     t = rvlc_huffman_sf(ld_sf, ld_esc, +1);
 
                     scale_factor += t;
-                    if (scale_factor < 0)
+                    if (scale_factor < 0 || scale_factor > 255)
                         return 4;
 
                     ics->scale_factors[g][sfb] = scale_factor;


### PR DESCRIPTION
 - remove unused bit-reader initialization
 - fix typo in scale check
 - add missing scale check