### PR TITLE
Do not compile leftover of LATM

### DIFF
--- a/libfaad/decoder.c
+++ b/libfaad/decoder.c
@@ -233,6 +233,7 @@ unsigned char NeAACDecSetConfiguration(NeAACDecHandle hpDecoder,
 }
 
 
+#if 0
 static int latmCheck(latm_header *latm, bitfile *ld)
 {
     uint32_t good=0, bad=0, bits, m;
@@ -256,7 +257,7 @@ static int latmCheck(latm_header *latm, bitfile *ld)
 
     return (good>0);
 }
-
+#endif
 
 long NeAACDecInit(NeAACDecHandle hpDecoder,
                               unsigned char *buffer,

--- a/libfaad/syntax.c
+++ b/libfaad/syntax.c
@@ -2522,6 +2522,7 @@ static void adts_error_check(adts_header *adts, bitfile *ld)
 }
 
 /* LATM parsing functions */
+#if 0
 
 static uint32_t latm_get_value(bitfile *ld)
 {
@@ -2535,7 +2536,6 @@ static uint32_t latm_get_value(bitfile *ld)
 
     return value;
 }
-
 
 static uint32_t latmParsePayload(latm_header *latm, bitfile *ld)
 {
@@ -2559,7 +2559,6 @@ static uint32_t latmParsePayload(latm_header *latm, bitfile *ld)
 
     return framelen;
 }
-
 
 static uint32_t latmAudioMuxElement(latm_header *latm, bitfile *ld)
 {
@@ -2677,7 +2676,6 @@ static uint32_t latmAudioMuxElement(latm_header *latm, bitfile *ld)
           return 0;
 }
 
-
 uint32_t faad_latm_frame(latm_header *latm, bitfile *ld)
 {
     uint16_t len;
@@ -2705,3 +2703,4 @@ uint32_t faad_latm_frame(latm_header *latm, bitfile *ld)
     }
     return 0xFFFFFFFF;
 }
+#endif

--- a/libfaad/syntax.h
+++ b/libfaad/syntax.h
@@ -122,7 +122,9 @@ uint8_t reordered_spectral_data(NeAACDecStruct *hDecoder, ic_stream *ics, bitfil
 void DRM_aac_scalable_main_element(NeAACDecStruct *hDecoder, NeAACDecFrameInfo *hInfo,
                                    bitfile *ld, program_config *pce, drc_info *drc);
 #endif
+#if 0
 uint32_t faad_latm_frame(latm_header *latm, bitfile *ld);
+#endif
 
 #ifdef __cplusplus
 }


### PR DESCRIPTION
LATM support was disabled 15 years ago:
https://github.com/knik0/faad2/commit/b79b5a24a8dd65568aaef6a9f909b948ef5b94cd

Not compiling unreachable code makes coverage picture more clear. Currently 4 of 10 top in undiscovered complexity are LATM functions.