### PR TITLE
Fix "stack-buffer-overflow"

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -13,6 +13,7 @@ Makefile
 *.libs
 *.deps
 *.la
+*.log
 project/msvc/.vs/
 project/msvc/bin/
 project/msvc/intermediate/
@@ -25,10 +26,16 @@ aclocal.m4
 autom4te.cache
 compile
 config.guess
+config.h
 config.sub
+config.status
 configure
 depcomp
+faad2.spec
+include/faad.h
 INSTALL
 install-sh
+libtool
 ltmain.sh
 missing
+stamp-h1


### PR DESCRIPTION
In some cases result of `program_config_element` is ignored:
> 14496-4: 5.6.4.1.2.1.3: program_configuration_element()'s in access units shall be ignored

In the meantime, the only check in that method guarantees that number of channels does not exceed the limit.

This change adds check right before configuration is used.

Drive-by: add more gitignore items.