### PR TITLE
Fix "Index-out-of-bounds"

### DIFF
--- a/libfaad/syntax.c
+++ b/libfaad/syntax.c
@@ -369,9 +369,16 @@ static void decode_sce_lfe(NeAACDecStruct *hDecoder,
         hDecoder->internal_channel[channels+1] = channels+1;
     } else {
         if (hDecoder->pce_set)
+        {
+            if (hDecoder->pce.channels > MAX_CHANNELS)
+            {
+                hInfo->error = 22;
+                return;
+            }
             hDecoder->internal_channel[hDecoder->pce.sce_channel[tag]] = channels;
-        else
+        } else {
             hDecoder->internal_channel[channels] = channels;
+        }
     }
 
     hDecoder->fr_channels += hDecoder->element_output_channels[hDecoder->fr_ch_ele];
@@ -392,6 +399,11 @@ static void decode_cpe(NeAACDecStruct *hDecoder, NeAACDecFrameInfo *hInfo, bitfi
     if (hDecoder->fr_ch_ele+1 > MAX_SYNTAX_ELEMENTS)
     {
         hInfo->error = 13;
+        return;
+    }
+    if (hDecoder->pce_set && (hDecoder->pce.channels > MAX_CHANNELS))
+    {
+        hInfo->error = 22;
         return;
     }
 


### PR DESCRIPTION
Same reason as in https://github.com/knik0/faad2/pull/111

In some cases result of `program_config_element` is ignored:
> 14496-4: 5.6.4.1.2.1.3: program_configuration_element()'s in access units shall be ignored

In the meantime, the only check in that method guarantees that number of channels does not exceed the limit.

This change adds check right before configuration is used.