### PR TITLE
Fix "left shift of 1 by 31 places cannot be represented in type 'int'"

### DIFF
--- a/libfaad/bits.h
+++ b/libfaad/bits.h
@@ -150,7 +150,7 @@ static INLINE uint32_t faad_showbits(bitfile *ld, uint32_t bits)
 
     bits -= ld->bits_left;
     //return ((ld->bufa & bitmask[ld->bits_left]) << bits) | (ld->bufb >> (32 - bits));
-    return ((ld->bufa & ((1<<ld->bits_left)-1)) << bits) | (ld->bufb >> (32 - bits));
+    return ((ld->bufa & ((1u<<ld->bits_left)-1)) << bits) | (ld->bufb >> (32 - bits));
 }
 
 static INLINE void faad_flushbits(bitfile *ld, uint32_t bits)
@@ -217,20 +217,20 @@ static INLINE uint32_t faad_showbits_rev(bitfile *ld, uint32_t bits)
     {
         for (i = 0; i < bits; i++)
         {
-            if (ld->bufa & (1 << (i + (32 - ld->bits_left))))
-                B |= (1 << (bits - i - 1));
+            if (ld->bufa & (1u << (i + (32 - ld->bits_left))))
+                B |= (1u << (bits - i - 1));
         }
         return B;
     } else {
         for (i = 0; i < ld->bits_left; i++)
         {
-            if (ld->bufa & (1 << (i + (32 - ld->bits_left))))
-                B |= (1 << (bits - i - 1));
+            if (ld->bufa & (1u << (i + (32 - ld->bits_left))))
+                B |= (1u << (bits - i - 1));
         }
         for (i = 0; i < bits - ld->bits_left; i++)
         {
-            if (ld->bufb & (1 << (i + (32-ld->bits_left))))
-                B |= (1 << (bits - ld->bits_left - i - 1));
+            if (ld->bufb & (1u << (i + (32-ld->bits_left))))
+                B |= (1u << (bits - ld->bits_left - i - 1));
         }
         return B;
     }

--- a/libfaad/hcr.c
+++ b/libfaad/hcr.c
@@ -155,12 +155,12 @@ static void concat_bits(bits_t *b, bits_t *a)
     {
         /* maskoff superfluous high b bits */
         bl = b->bufa;
-        bh = b->bufb & ((1 << (b->len-32)) - 1);
+        bh = b->bufb & ((1u << (b->len-32)) - 1);
         /* left shift a b->len bits */
         ah = al << (b->len - 32);
         al = 0;
     } else {
-        bl = b->bufa & ((1 << (b->len)) - 1);
+        bl = b->bufa & ((1u << (b->len)) - 1);
         bh = 0;
         ah = (ah << (b->len)) | (al >> (32 - b->len));
         al = al << b->len;

--- a/libfaad/sbr_syntax.c
+++ b/libfaad/sbr_syntax.c
@@ -674,7 +674,7 @@ static uint8_t sbr_grid(bitfile *ld, sbr_info *sbr, uint8_t ch)
         i = (uint8_t)faad_getbits(ld, 2
             DEBUGVAR(1,249,"sbr_grid(): bs_num_env_raw"));
 
-        bs_num_env = min(1 << i, 5);
+        bs_num_env = min(1u << i, 5u);
 
         i = (uint8_t)faad_get1bit(ld
             DEBUGVAR(1,250,"sbr_grid(): bs_freq_res_flag"));

--- a/libfaad/syntax.c
+++ b/libfaad/syntax.c
@@ -1733,7 +1733,7 @@ static uint8_t section_data(NeAACDecStruct *hDecoder, ic_stream *ics, bitfile *l
         sect_bits = 3;
     else
         sect_bits = 5;
-    sect_esc_val = (1<<sect_bits) - 1;
+    sect_esc_val = (1u<<sect_bits) - 1;
 
 #if 0
     printf("\ntotal sfb %d\n", ics->max_sfb);


### PR DESCRIPTION
Problem was in faad_showbits faad2/libfaad/bits.h:153:28

Drive-by: fix other similar left shifts