### PR TITLE
Fix "Undefined-shift in showbits_hcr"

### DIFF
--- a/libfaad/hcr.c
+++ b/libfaad/hcr.c
@@ -386,7 +386,13 @@ uint8_t reordered_spectral_data(NeAACDecStruct *hDecoder, ic_stream *ics,
 
                 if (!codeword[codeword_idx].decoded && segment[segment_idx].len > 0)
                 {
-                    uint8_t tmplen;
+                    uint8_t tmplen = segment[segment_idx].len + codeword[codeword_idx].bits.len;
+
+                    if (tmplen > 64)
+                    {
+                      // Drop bits that do not fit concatenation result.
+                      flushbits_hcr(&codeword[codeword_idx].bits, tmplen - 64);
+                    }
 
                     if (codeword[codeword_idx].bits.len != 0)
                         concat_bits(&segment[segment_idx], &codeword[codeword_idx].bits);


### PR DESCRIPTION
HCR tries to do the best in the case of broken input; Fuzzer has found the case that forces HCR to concatenate 2 segments with the resulting length more than 64.

Let's drop the extra bits - correct streams are not affected, broken streams will likely do a bit better
(due to absence of UB shift).