### PR TITLE
CI: compile with both Clang and GCC

### DIFF
--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -35,6 +35,22 @@ on:
 jobs:
   BuildWithAutomake:
     runs-on: ubuntu-latest
+
+    strategy:
+     fail-fast: false
+     matrix:
+       include:
+         - name: clang
+           cc: clang
+           cxx: clang++
+         - name: gcc
+           cc: gcc
+           cxx: g++
+
+    env:
+      CC: ${{ matrix.cc || 'cc' }}
+      CXX: ${{ matrix.cxx || 'cxx' }}
+
     steps:
     - name: Checkout the source
       uses: actions/checkout@v2


### PR DESCRIPTION
Those two often produce different set of warnings. Often both are fair as well.