### PR TITLE
Fix Undefined-shift in showbits_hcr

### DIFF
--- a/libfaad/huffman.c
+++ b/libfaad/huffman.c
@@ -546,6 +546,9 @@ int8_t huffman_spectral_data_2(uint8_t cb, bits_t *ld, int16_t *sp)
                         break;
                 }
 
+                if (i > 32)
+                    return -1;
+
                 if (getbits_hcr(ld, i, &off))
                     return -1;
                 j = off + (1<<i);


### PR DESCRIPTION
After oreceding loop `i` can be up to 4+64;
but showbits_hcr should not be requested more than 32 bits.