### PR TITLE
Improve fuzzer coverage

### DIFF
--- a/fuzz/fuzz_config.c
+++ b/fuzz/fuzz_config.c
@@ -34,6 +34,23 @@
 #include "neaacdec.h"
 
 int LLVMFuzzerTestOneInput(const uint8_t* data, size_t size) {
+  long sink = 0;
+
+  if (size < 1) return 0;
+  unsigned char error_code = *(data++);
+  size -= 1;
+
+  char* error_message = NeAACDecGetErrorMessage(error_code);
+  if (error_message) sink += strlen(error_message);
+
+  char* id = NULL;
+  char* copyright = NULL;
+  sink += NeAACDecGetVersion(&id, &copyright);
+  sink += strlen(id);
+  sink += strlen(copyright);
+
+  sink += (long)NeAACDecGetCapabilities();
+
   unsigned char* non_const_data = (unsigned char *)malloc(size);
   memcpy(non_const_data, data, size);
   mp4AudioSpecificConfig mp4ASC;
@@ -41,5 +58,5 @@ int LLVMFuzzerTestOneInput(const uint8_t* data, size_t size) {
   NeAACDecAudioSpecificConfig(non_const_data, (unsigned long) size, &mp4ASC);
   free(non_const_data);
 
-  return 0;
+  return (sink < 0) ? sink : 0;
 }

--- a/libfaad/bits.c
+++ b/libfaad/bits.c
@@ -126,6 +126,7 @@ void faad_flushbits_ex(bitfile *ld, uint32_t bits)
 //        ld->error = 1;
 }
 
+#ifdef DRM
 /* rewind to beginning */
 void faad_rewindbits(bitfile *ld)
 {
@@ -156,6 +157,7 @@ void faad_rewindbits(bitfile *ld)
     ld->bits_left = 32;
     ld->tail = &ld->start[2];
 }
+#endif
 
 /* reset to a certain point */
 void faad_resetbits(bitfile *ld, int bits)
@@ -239,6 +241,7 @@ uint32_t faad_origbitbuffer_size(bitfile *ld)
 }
 #endif
 
+#if 0
 /* reversed bit reading routines, used for RVLC and HCR */
 void faad_initbits_rev(bitfile *ld, void *buffer,
                        uint32_t bits_in_buffer)
@@ -267,5 +270,6 @@ void faad_initbits_rev(bitfile *ld, void *buffer,
     ld->bytes_left = ld->buffer_size;
     ld->error = 0;
 }
+#endif
 
 /* EOF */

--- a/libfaad/bits.h
+++ b/libfaad/bits.h
@@ -74,12 +74,16 @@ static uint32_t const bitmask[] = {
 
 void faad_initbits(bitfile *ld, const void *buffer, const uint32_t buffer_size);
 void faad_endbits(bitfile *ld);
+#if 0
 void faad_initbits_rev(bitfile *ld, void *buffer,
                        uint32_t bits_in_buffer);
+#endif
 uint8_t faad_byte_align(bitfile *ld);
 uint32_t faad_get_processed_bits(bitfile *ld);
 void faad_flushbits_ex(bitfile *ld, uint32_t bits);
+#ifdef DRM
 void faad_rewindbits(bitfile *ld);
+#endif
 void faad_resetbits(bitfile *ld, int bits);
 uint8_t *faad_getbitbuffer(bitfile *ld, uint32_t bits
                        DEBUGDEC);
@@ -207,6 +211,7 @@ static INLINE uint8_t faad_get1bit(bitfile *ld DEBUGDEC)
     return r;
 }
 
+#if 0
 /* reversed bitreading routines */
 static INLINE uint32_t faad_showbits_rev(bitfile *ld, uint32_t bits)
 {
@@ -284,6 +289,7 @@ static /*INLINE*/ uint32_t faad_getbits_rev(bitfile *ld, uint32_t n
 
     return ret;
 }
+#endif
 
 #ifdef DRM
 /* CRC lookup table for G8 polynome in DRM standard */

--- a/libfaad/cfft.c
+++ b/libfaad/cfft.c
@@ -74,6 +74,13 @@ static void passf2pos(const uint16_t ido, const uint16_t l1, const complex_t *cc
 
     if (ido == 1)
     {
+#ifdef FUZZING_BUILD_MODE_UNSAFE_FOR_PRODUCTION
+        // TODO: remove this code once fuzzer proves it is totally unreahable
+        // For supported frame lengths that have odd number of factor 2 it is
+        // never the last factor; consequently `ido` should never be 1.
+        __builtin_trap();
+        /*
+#endif
         for (k = 0; k < l1; k++)
         {
             ah = 2*k;
@@ -84,6 +91,9 @@ static void passf2pos(const uint16_t ido, const uint16_t l1, const complex_t *cc
             IM(ch[ah])    = IM(cc[ac]) + IM(cc[ac+1]);
             IM(ch[ah+l1]) = IM(cc[ac]) - IM(cc[ac+1]);
         }
+#ifdef FUZZING_BUILD_MODE_UNSAFE_FOR_PRODUCTION
+        */
+#endif
     } else {
         for (k = 0; k < l1; k++)
         {
@@ -119,6 +129,13 @@ static void passf2neg(const uint16_t ido, const uint16_t l1, const complex_t *cc
 
     if (ido == 1)
     {
+#ifdef FUZZING_BUILD_MODE_UNSAFE_FOR_PRODUCTION
+        // TODO: remove this code once fuzzer proves it is totally unreahable
+        // For supported frame lengths that have odd number of factor 2 it is
+        // never the last factor; consequently `ido` should never be 1.
+        __builtin_trap();
+        /*
+#endif
         for (k = 0; k < l1; k++)
         {
             ah = 2*k;
@@ -129,6 +146,9 @@ static void passf2neg(const uint16_t ido, const uint16_t l1, const complex_t *cc
             IM(ch[ah])    = IM(cc[ac]) + IM(cc[ac+1]);
             IM(ch[ah+l1]) = IM(cc[ac]) - IM(cc[ac+1]);
         }
+#ifdef FUZZING_BUILD_MODE_UNSAFE_FOR_PRODUCTION
+        */
+#endif
     } else {
         for (k = 0; k < l1; k++)
         {
@@ -169,6 +189,13 @@ static void passf3(const uint16_t ido, const uint16_t l1, const complex_t *cc,
 
     if (ido == 1)
     {
+#ifdef FUZZING_BUILD_MODE_UNSAFE_FOR_PRODUCTION
+        // TODO: remove this code once fuzzer proves it is totally unreahable
+        // 3 is never the the biggest factor for supported frame lengths;
+        // consequently `ido` should never be 1.
+        __builtin_trap();
+        /*
+#endif
         if (isign == 1)
         {
             for (k = 0; k < l1; k++)
@@ -215,6 +242,9 @@ static void passf3(const uint16_t ido, const uint16_t l1, const complex_t *cc,
                 IM(ch[ah+2*l1]) = IM(c2) + RE(c3);
             }
         }
+#ifdef FUZZING_BUILD_MODE_UNSAFE_FOR_PRODUCTION
+        */
+#endif
     } else {
         if (isign == 1)
         {
@@ -560,6 +590,13 @@ static void passf5(const uint16_t ido, const uint16_t l1, const complex_t *cc,
             }
         }
     } else {
+#ifdef FUZZING_BUILD_MODE_UNSAFE_FOR_PRODUCTION
+        // TODO: remove this code once fuzzer proves it is totally unreahable
+        // 5 if the biggest factor and it never repeated for supported frame
+        // lengths; consequently `ido` should always be 1.
+        __builtin_trap();
+        /*
+#endif
         if (isign == 1)
         {
             for (k = 0; k < l1; k++)
@@ -682,6 +719,9 @@ static void passf5(const uint16_t ido, const uint16_t l1, const complex_t *cc,
                 }
             }
         }
+#ifdef FUZZING_BUILD_MODE_UNSAFE_FOR_PRODUCTION
+        */
+#endif
     }
 }
 

--- a/libfaad/common.c
+++ b/libfaad/common.c
@@ -244,6 +244,8 @@ uint32_t ne_rng(uint32_t *__r1, uint32_t *__r2)
     return (*__r1 = (t3 >> 1) | t1 ) ^ (*__r2 = (t4 + t4) | t2 );
 }
 
+#ifdef FIXED_POINT
+
 static uint32_t ones32(uint32_t x)
 {
     x -= ((x >> 1) & 0x55555555);
@@ -296,8 +298,6 @@ uint32_t wl_min_lzc(uint32_t x)
     return (count + 1);
 #endif
 }
-
-#ifdef FIXED_POINT
 
 #define TABLE_BITS 6
 /* just take the maximum number of bits for interpolation */

--- a/libfaad/common.h
+++ b/libfaad/common.h
@@ -412,8 +412,8 @@ typedef real_t complex_t[2];
 /* common functions */
 uint8_t cpu_has_sse(void);
 uint32_t ne_rng(uint32_t *__r1, uint32_t *__r2);
-uint32_t wl_min_lzc(uint32_t x);
 #ifdef FIXED_POINT
+uint32_t wl_min_lzc(uint32_t x);
 #define LOG2_MIN_INF REAL_CONST(-10000)
 int32_t log2_int(uint32_t val);
 int32_t log2_fix(uint32_t val);

--- a/libfaad/decoder.c
+++ b/libfaad/decoder.c
@@ -836,7 +836,7 @@ void* NeAACDecDecode2(NeAACDecHandle hpDecoder,
                                   unsigned long sample_buffer_size)
 {
     NeAACDecStruct* hDecoder = (NeAACDecStruct*)hpDecoder;
-    if ((sample_buffer == NULL) || (sample_buffer_size == 0))
+    if ((sample_buffer == NULL) || (*sample_buffer == NULL) || (sample_buffer_size == 0))
     {
         hInfo->error = 27;
         return NULL;

--- a/libfaad/huffman.c
+++ b/libfaad/huffman.c
@@ -52,7 +52,9 @@ static uint8_t huffman_binary_quad(uint8_t cb, bitfile *ld, int16_t *sp);
 static uint8_t huffman_binary_quad_sign(uint8_t cb, bitfile *ld, int16_t *sp);
 static uint8_t huffman_binary_pair(uint8_t cb, bitfile *ld, int16_t *sp);
 static uint8_t huffman_binary_pair_sign(uint8_t cb, bitfile *ld, int16_t *sp);
+#if 0
 static int16_t huffman_codebook(uint8_t i);
+#endif
 static void vcb11_check_LAV(uint8_t cb, int16_t *sp);
 
 int8_t huffman_scale_factor(bitfile *ld)
@@ -311,12 +313,14 @@ static uint8_t huffman_binary_pair_sign(uint8_t cb, bitfile *ld, int16_t *sp)
     return err;
 }
 
+#if 0
 static int16_t huffman_codebook(uint8_t i)
 {
     static const uint32_t data = 16428320;
     if (i == 0) return (int16_t)(data >> 16) & 0xFFFF;
     else        return (int16_t)data & 0xFFFF;
 }
+#endif
 
 static void vcb11_check_LAV(uint8_t cb, int16_t *sp)
 {
@@ -359,10 +363,13 @@ uint8_t huffman_spectral_data(uint8_t cb, bitfile *ld, int16_t *sp)
     case 8: /* 2-step method for data pairs */
     case 10:
         return huffman_2step_pair_sign(cb, ld, sp);
+    /* Codebook 12 is disallowed, see `section_data` */
+#if 0
     case 12: {
         uint8_t err = huffman_2step_pair(11, ld, sp);
         sp[0] = huffman_codebook(0); sp[1] = huffman_codebook(1);
         return err; }
+#endif
     case 11:
     {
         uint8_t err = huffman_2step_pair_sign(11, ld, sp);

--- a/libfaad/rvlc.c
+++ b/libfaad/rvlc.c
@@ -66,9 +66,9 @@ static uint8_t rvlc_decode_sf_reverse(ic_stream *ics,
                                       bitfile *ld_esc,
                                       uint8_t is_used);
 #endif
-static int8_t rvlc_huffman_sf(bitfile *ld_sf, bitfile *ld_esc,
-                              int8_t direction);
-static int8_t rvlc_huffman_esc(bitfile *ld_esc, int8_t direction);
+static int8_t rvlc_huffman_sf(bitfile *ld_sf, bitfile *ld_esc /*,
+                              int8_t direction*/);
+static int8_t rvlc_huffman_esc(bitfile *ld_esc /*, int8_t direction*/);
 
 
 uint8_t rvlc_scale_factor_data(ic_stream *ics, bitfile *ld)
@@ -205,7 +205,7 @@ static uint8_t rvlc_decode_sf_forward(ic_stream *ics, bitfile *ld_sf, bitfile *l
                     *intensity_used = 1;
 
                     /* decode intensity position */
-                    t = rvlc_huffman_sf(ld_sf, ld_esc, +1);
+                    t = rvlc_huffman_sf(ld_sf, ld_esc /*, +1*/);
 
                     is_position += t;
                     if (is_position < 0 || is_position > 255)
@@ -222,7 +222,7 @@ static uint8_t rvlc_decode_sf_forward(ic_stream *ics, bitfile *ld_sf, bitfile *l
                         noise_pcm_flag = 0;
                         noise_energy += n;
                     } else {
-                        t = rvlc_huffman_sf(ld_sf, ld_esc, +1);
+                        t = rvlc_huffman_sf(ld_sf, ld_esc /*, +1*/);
                         noise_energy += t;
                     }
 
@@ -234,7 +234,7 @@ static uint8_t rvlc_decode_sf_forward(ic_stream *ics, bitfile *ld_sf, bitfile *l
                 default: /* spectral books */
 
                     /* decode scale factor */
-                    t = rvlc_huffman_sf(ld_sf, ld_esc, +1);
+                    t = rvlc_huffman_sf(ld_sf, ld_esc /*, +1*/);
 
                     scale_factor += t;
                     if (scale_factor < 0 || scale_factor > 255)
@@ -455,19 +455,20 @@ static rvlc_huff_table book_escape[] = {
     { 99, 21,  0 } /* Shouldn't come this far */
 };
 
-static int8_t rvlc_huffman_sf(bitfile *ld_sf, bitfile *ld_esc,
-                              int8_t direction)
+static int8_t rvlc_huffman_sf(bitfile *ld_sf, bitfile *ld_esc /*,
+                              int8_t direction*/)
 {
     uint8_t i, j;
     int8_t index;
     uint32_t cw;
     rvlc_huff_table *h = book_rvlc;
+    int8_t direction = +1;
 
     i = h->len;
     if (direction > 0)
         cw = faad_getbits(ld_sf, i DEBUGVAR(1,0,""));
-    else
-        cw = faad_getbits_rev(ld_sf, i DEBUGVAR(1,0,""));
+    // else
+    //     cw = faad_getbits_rev(ld_sf, i DEBUGVAR(1,0,""));
 
     while ((cw != h->cw)
         && (i < 10))
@@ -478,15 +479,15 @@ static int8_t rvlc_huffman_sf(bitfile *ld_sf, bitfile *ld_esc,
         cw <<= j;
         if (direction > 0)
             cw |= faad_getbits(ld_sf, j DEBUGVAR(1,0,""));
-        else
-            cw |= faad_getbits_rev(ld_sf, j DEBUGVAR(1,0,""));
+        // else
+        //     cw |= faad_getbits_rev(ld_sf, j DEBUGVAR(1,0,""));
     }
 
     index = h->index;
 
     if (index == +ESC_VAL)
     {
-        int8_t esc = rvlc_huffman_esc(ld_esc, direction);
+        int8_t esc = rvlc_huffman_esc(ld_esc /*, direction*/);
         if (esc == 99)
             return 99;
         index += esc;
@@ -496,7 +497,7 @@ static int8_t rvlc_huffman_sf(bitfile *ld_sf, bitfile *ld_esc,
     }
     if (index == -ESC_VAL)
     {
-        int8_t esc = rvlc_huffman_esc(ld_esc, direction);
+        int8_t esc = rvlc_huffman_esc(ld_esc /*, direction*/);
         if (esc == 99)
             return 99;
         index -= esc;
@@ -508,18 +509,19 @@ static int8_t rvlc_huffman_sf(bitfile *ld_sf, bitfile *ld_esc,
     return index;
 }
 
-static int8_t rvlc_huffman_esc(bitfile *ld,
-                               int8_t direction)
+static int8_t rvlc_huffman_esc(bitfile *ld /*,
+                               int8_t direction*/)
 {
     uint8_t i, j;
     uint32_t cw;
     rvlc_huff_table *h = book_escape;
+    int8_t direction = +1;
 
     i = h->len;
     if (direction > 0)
         cw = faad_getbits(ld, i DEBUGVAR(1,0,""));
-    else
-        cw = faad_getbits_rev(ld, i DEBUGVAR(1,0,""));
+    // else
+    //     cw = faad_getbits_rev(ld, i DEBUGVAR(1,0,""));
 
     while ((cw != h->cw)
         && (i < 21))
@@ -530,8 +532,8 @@ static int8_t rvlc_huffman_esc(bitfile *ld,
         cw <<= j;
         if (direction > 0)
             cw |= faad_getbits(ld, j DEBUGVAR(1,0,""));
-        else
-            cw |= faad_getbits_rev(ld, j DEBUGVAR(1,0,""));
+        // else
+        //     cw |= faad_getbits_rev(ld, j DEBUGVAR(1,0,""));
     }
 
     return h->index;


### PR DESCRIPTION
 - add more method calls in fuzzers
 - hide behind ifdef statically unreachable code
 - comment-out directionality param that is always "forward"
 - hide behind fuzzer-specific ifdef code that is theoretically unreachable; if fuzzer ever will find a way there, it will report