### PR TITLE
Fix: shift exponent 32 is too large for 32-bit type 'uint32_t'

### DIFF
--- a/fuzz/build_fuzz.sh
+++ b/fuzz/build_fuzz.sh
@@ -34,7 +34,7 @@ export SANITIZER_FLAGS="-fsanitize=$SANITIZER -fsanitize-address-use-after-scope
 #export SANITIZER_FLAGS="-fsanitize=$SANITIZER -fsanitize-memory-track-origins=2"
 # UBSAN:
 #export SANITIZER=array-bounds,bool,builtin,enum,float-divide-by-zero,function,integer-divide-by-zero,null,object-size,return,returns-nonnull-attribute,shift,signed-integer-overflow,unsigned-integer-overflow,unreachable,vla-bound,vptr
-#export SANITIZER_FLAGS="-fsanitize=$SANITIZER -fno-sanitize-recover=$SANITIZER"
+#export SANITIZER_FLAGS="-fsanitize=$SANITIZER -fno-sanitize-recover=$SANITIZER -fsanitize-recover=unsigned-integer-overflow"
 
 export CC="clang"
 export CXX="clang++"

--- a/libfaad/sbr_fbt.c
+++ b/libfaad/sbr_fbt.c
@@ -193,7 +193,7 @@ uint8_t master_frequency_table_fs0(sbr_info *sbr, uint8_t k0, uint8_t k2,
     int8_t incr;
     uint8_t k;
     uint8_t dk;
-    uint32_t nrBands, k2Achieved;
+    int32_t nrBands, k2Achieved;
     int32_t k2Diff, vDk[64] = {0};
 
     /* mft only defined for k2 > k0 */


### PR DESCRIPTION
Drive-by: comb `showbits_hcr`
Drive-by: do not count unsigned-overflow as fatal (since that is not UB)
Drive-by: fix intermediate underflow in `master_frequency_table_fs0`