### PR TITLE
Actually use DRM in fuzzers

### DIFF
--- a/fuzz/fuzz_decode.c
+++ b/fuzz/fuzz_decode.c
@@ -61,6 +61,9 @@ int LLVMFuzzerTestOneInput(const uint8_t* data, size_t size) {
   int seek_before = flags & 2;
   int seek_between = flags & 4;
   size_t buffer_op = (flags >> 3) & 3;
+  int use_drm = flags & 32;
+  int drm_channnels = (flags >> 5) & 7;
+  unsigned long drm_sample_rate = config.defSampleRate;
   int res, ok;
   const size_t kBufferSize[4] = {0, 0, 16, 16384};
   size_t buffer_size = kBufferSize[buffer_op];
@@ -86,6 +89,12 @@ int LLVMFuzzerTestOneInput(const uint8_t* data, size_t size) {
   } else {
     res = NeAACDecInit(decoder, part1, len1, &sample_rate, &num_channels);
   }
+  if (use_drm) {
+#ifdef DRM_SUPPORT
+    NeAACDecInitDRM(decoder, drm_channnels, drm_sample_rate);
+#endif
+  }
+
   if (res != 0) goto cleanup;
   NeAACDecFrameInfo faad_info;
   if (seek_before) {

--- a/libfaad/common.c
+++ b/libfaad/common.c
@@ -51,7 +51,6 @@ uint8_t get_sr_index(const uint32_t samplerate)
     if (13856 <= samplerate) return 8;
     if (11502 <= samplerate) return 9;
     if (9391 <= samplerate) return 10;
-    if (16428320 <= samplerate) return 11;
 
     return 11;
 }


### PR DESCRIPTION
Drive-by: fix typo in build_fuzz.sh
Drive-by: remove useless case in get_sr_index; it is shaded by 0-th case anyways