### PR TITLE
Fixes #143

### DIFF
--- a/libfaad/pns.c
+++ b/libfaad/pns.c
@@ -94,6 +94,8 @@ static INLINE void gen_rand_vector(real_t *spec, int16_t scale_factor, uint16_t 
     uint16_t i;
     real_t energy = 0.0;
 
+    scale_factor = min(max(scale_factor, -120), 120);
+
     for (i = 0; i < size; i++)
     {
         real_t tmp = (real_t)(int32_t)ne_rng(__r1, __r2);
@@ -115,6 +117,14 @@ static INLINE void gen_rand_vector(real_t *spec, int16_t scale_factor, uint16_t 
     real_t energy = 0, scale;
     int32_t exp, frac;
 
+    /* IMDCT pre-scaling */
+    scale_factor -= 4 * sub;
+
+    scale_factor = min(max(scale_factor, -60), 60);
+
+    exp = scale_factor >> 2;
+    frac = scale_factor & 3;
+
     for (i = 0; i < size; i++)
     {
         /* this can be replaced by a 16 bit random generator!!!! */
@@ -128,17 +138,12 @@ static INLINE void gen_rand_vector(real_t *spec, int16_t scale_factor, uint16_t 
 
         spec[i] = tmp;
     }
+    /* energy ~= size / 3 */
 
     energy = fp_sqrt(energy);
     if (energy > 0)
     {
         scale = DIV(REAL_CONST(1),energy);
-
-        exp = scale_factor >> 2;
-        frac = scale_factor & 3;
-
-        /* IMDCT pre-scaling */
-        exp -= sub;
 
         if (exp < 0)
             scale >>= -exp;

--- a/libfaad/rvlc.c
+++ b/libfaad/rvlc.c
@@ -208,8 +208,6 @@ static uint8_t rvlc_decode_sf_forward(ic_stream *ics, bitfile *ld_sf, bitfile *l
                     t = rvlc_huffman_sf(ld_sf, ld_esc /*, +1*/);
 
                     is_position += t;
-                    if (is_position < 0 || is_position > 255)
-                        return 4;
                     ics->scale_factors[g][sfb] = is_position;
 
                     break;
@@ -226,8 +224,6 @@ static uint8_t rvlc_decode_sf_forward(ic_stream *ics, bitfile *ld_sf, bitfile *l
                         noise_energy += t;
                     }
 
-                    if (noise_energy < 0 || noise_energy > 255)
-                        return 4;
                     ics->scale_factors[g][sfb] = noise_energy;
 
                     break;

--- a/libfaad/structs.h
+++ b/libfaad/structs.h
@@ -259,7 +259,7 @@ typedef struct
     uint8_t num_sec[8]; /* number of sections in a group */
 
     uint8_t global_gain;
-    int16_t scale_factors[8][51]; /* [0..255] */
+    int16_t scale_factors[8][51]; /* [0..255], except for noise and intensity */
 
     uint8_t ms_mask_present;
     uint8_t ms_used[MAX_WINDOW_GROUPS][MAX_SFB];

--- a/libfaad/syntax.c
+++ b/libfaad/syntax.c
@@ -1918,8 +1918,6 @@ static uint8_t decode_scale_factors(ic_stream *ics, bitfile *ld)
                 /* decode intensity position */
                 t = huffman_scale_factor(ld);
                 is_position += (t - 60);
-                if (is_position < 0 || is_position > 255)
-                    return 4;
                 ics->scale_factors[g][sfb] = is_position;
 #ifdef SF_PRINT
                 printf("%d\n", ics->scale_factors[g][sfb]);
@@ -1940,8 +1938,6 @@ static uint8_t decode_scale_factors(ic_stream *ics, bitfile *ld)
                     t -= 60;
                 }
                 noise_energy += t;
-                if (noise_energy < 0 || noise_energy > 255)
-                    return 4;
                 ics->scale_factors[g][sfb] = noise_energy;
 #ifdef SF_PRINT
                 printf("%d\n", ics->scale_factors[g][sfb]);


### PR DESCRIPTION
In earlier changelist, following the comments on scale_factor
field I've "unified" checking of scale_factor for all 3 major cases.
That was a mistake. Some files stopped decoding failing exactly
at point where scale_factor is checked.

There are 3 types of scale_factor: "quant", "intensity" and "noise".

"intensity" and "noise" scale_factors have different meaning.
Removed checks at parsing time for them and added capping at processing.

"noise" scale_factor stands for magnitude of generated signal.
Large negative factor means inaudible noise. On encoder side
(e.g. in FAAC) it is even replaced with "silence" after some threshold
(MSE < 0.4, it renders to exp ~= -6).
Large positive factor means "loud" noise. Again too-big values simply
does not fit output format.
Same reasoning applies to floating point calculations.
For floating point noise scale factor is capped with [-120,120] range,
i.e. scale is (9.3e-10,1.7e+9)
For fixed poind noise scale factor is capped with [-60,60].

"intensity" stands for "joint stereo". In FAAC encoder if
the difference between scale_factor is 30 or more, the quieter channel
is encoded as silence. I.e. if difference in power more than 180
that feels like there is only one audio source.
Given that same cap is applied to "intensity" scale_factor.

Moreover, for "quant" scale_factor limit is 0..255 with an offset of 100,
i.e. it is -100..155; close enough to the new limits for other two
scale_factor.