### PR TITLE
Frontend: do not swallow the first frame

### DIFF
--- a/frontend/audio.c
+++ b/frontend/audio.c
@@ -111,19 +111,19 @@ audio_file *open_audio_file(char *infile, int samplerate, int channels,
     return aufile;
 }
 
-int write_audio_file(audio_file *aufile, void *sample_buffer, int samples, int offset)
+int write_audio_file(audio_file *aufile, void *sample_buffer, int samples)
 {
     char *buf = (char *)sample_buffer;
     switch (aufile->outputFormat)
     {
     case FAAD_FMT_16BIT:
-        return write_audio_16bit(aufile, buf + offset*2, samples);
+        return write_audio_16bit(aufile, buf, samples);
     case FAAD_FMT_24BIT:
-        return write_audio_24bit(aufile, buf + offset*4, samples);
+        return write_audio_24bit(aufile, buf, samples);
     case FAAD_FMT_32BIT:
-        return write_audio_32bit(aufile, buf + offset*4, samples);
+        return write_audio_32bit(aufile, buf, samples);
     case FAAD_FMT_FLOAT:
-        return write_audio_float(aufile, buf + offset*4, samples);
+        return write_audio_float(aufile, buf, samples);
     default:
         return 0;
     }

--- a/frontend/audio.h
+++ b/frontend/audio.h
@@ -55,7 +55,7 @@ typedef struct
 
 audio_file *open_audio_file(char *infile, int samplerate, int channels,
                             int outputFormat, int fileType, long channelMask);
-int write_audio_file(audio_file *aufile, void *sample_buffer, int samples, int offset);
+int write_audio_file(audio_file *aufile, void *sample_buffer, int samples);
 void close_audio_file(audio_file *aufile);
 
 #ifdef __cplusplus

--- a/frontend/main.c
+++ b/frontend/main.c
@@ -666,6 +666,9 @@ static int decodeAACfile(char *aacfile, char *sndfile, char *adts_fn, int to_std
         break;
     }
 
+    // Override the logic of skipping 0-th output frame.
+    NeAACDecPostSeekReset(hDecoder, 1);
+
     if (infoOnly)
     {
         NeAACDecClose(hDecoder);
@@ -754,7 +757,7 @@ static int decodeAACfile(char *aacfile, char *sndfile, char *adts_fn, int to_std
 
         if ((frameInfo.error == 0) && (frameInfo.samples > 0) && (!adts_out))
         {
-            if (write_audio_file(aufile, sample_buffer, frameInfo.samples, 0) == 0)
+            if (write_audio_file(aufile, sample_buffer, frameInfo.samples) == 0)
                 break;
         }
 
@@ -907,7 +910,6 @@ static int decodeMP4file(char *mp4file, char *sndfile, char *adts_fn, int to_std
         /*int rc;*/
         long dur;
         unsigned int sample_count;
-        unsigned int delay = 0;
 
         if (mp4read_frame())
             break;
@@ -997,7 +999,7 @@ static int decodeMP4file(char *mp4file, char *sndfile, char *adts_fn, int to_std
 
         if ((frameInfo.error == 0) && (sample_count > 0) && (!adts_out))
         {
-            if (write_audio_file(aufile, sample_buffer, sample_count, delay) == 0)
+            if (write_audio_file(aufile, sample_buffer, sample_count) == 0)
                 break;
         }
 
@@ -1153,6 +1155,8 @@ static int faad_main(int argc, char *argv[])
                 } else {
                     outputFormat = atoi(dr);
                     if ((outputFormat < 1) || (outputFormat > 5))
+                        showHelp = 1;
+                    if (outputFormat == 5)  // Not yet unsupported by "audio".
                         showHelp = 1;
                 }
             }


### PR DESCRIPTION
Other tools don't. Typically encoder input is primed, so there is no reason to drop decoded data.

Drive-by: remove unused parameter in write_audio_file.
Drive-by: report when unsupported output format (double) is requested.