### PR TITLE
Further fix UB in PNS

### DIFF
--- a/libfaad/decoder.c
+++ b/libfaad/decoder.c
@@ -148,8 +148,9 @@ NeAACDecHandle NeAACDecOpen(void)
     hDecoder->frame = 0;
     hDecoder->sample_buffer = NULL;
 
-    hDecoder->__r1 = 1;
-    hDecoder->__r2 = 1;
+    // Same as (1, 1) after 1024 iterations; otherwise first values does not look random at all.
+    hDecoder->__r1 = 0x2bb431ea;
+    hDecoder->__r2 = 0x206155b7;
 
     for (i = 0; i < MAX_CHANNELS; i++)
     {


### PR DESCRIPTION
And simplify code. Given the nature of noise we do not have to match noise energy exactly. Matching the expected energy seems to be good enough, and have much cleaner code. Now we do not need FP division and square root.

Drive-by: random values did not look random at all because our shift-registers need some
          time (iterations) to turn (1, 1) to something less obvious; virtually primed
	  RNG with 1024 iterations