### PR TITLE
Fix #171

### DIFF
--- a/frontend/mp4read.c
+++ b/frontend/mp4read.c
@@ -444,8 +444,8 @@ static int stcoin(int size)
             chunkn++;
             if (chunkn > numchunks)
                 return ERR_FAIL;
-            if (slicen < mp4config.frame.nsclices)
-            {
+            if (slicen < mp4config.frame.nsclices &&
+                (slicen + 1) < mp4config.frame.nsclices) {
                 if (chunkn == mp4config.frame.map[slicen + 1].firstchunk)
                     slicen++;
             }


### PR DESCRIPTION
(slicen + 1) should not run after the array boundary; to avoid possible overflow, we now check in 2 steps, chained with short-circuit-and.