### PR TITLE
Add define option to disable SBR/PS support.

### DIFF
--- a/libfaad/common.h
+++ b/libfaad/common.h
@@ -122,13 +122,18 @@ extern "C" {
   #undef ERROR_RESILIENCE
 #endif
 
-#define SBR_DEC
-//#define SBR_LOW_POWER
-#define PS_DEC
+// Define DISABLE_SBR if you want to disable SBR decoding.
+//#define DISABLE_SBR
 
-#ifdef SBR_LOW_POWER
-#undef PS_DEC
-#endif
+// Define SBR_LOW_POWER if you want only low power SBR decoding without PS.
+//#define SBR_LOW_POWER
+
+#ifndef DISABLE_SBR
+# define SBR_DEC
+# ifndef SBR_LOW_POWER
+#  define PS_DEC
+# endif // SBR_LOW_POWER
+#endif // DISABLE_SBR
 
 /* FIXED POINT: No MAIN decoding */
 #ifdef FIXED_POINT


### PR DESCRIPTION
I need to be able to make builds with SBR/PS disabled on top of the flags controlled by `LC_ONLY_DECODER`. Currently this is not possible without modifying source files as they are hard-defined in `common.h` with no condition.

In order to support this, add `DISABLE_SBR` to allow disabling these while still keeping them controllable independently of `LC_ONLY_DECODER`.