### PR TITLE
Fix coefficient table selection in tns_decode_coef.

### DIFF
--- a/libfaad/tns.c
+++ b/libfaad/tns.c
@@ -196,7 +196,7 @@ static uint8_t tns_decode_coef(uint8_t order, uint8_t coef_res_bits, uint8_t coe
 {
     uint8_t i, m;
     real_t tmp2[TNS_MAX_ORDER+1], b[TNS_MAX_ORDER+1];
-    uint8_t table_index = 2 * (coef_compress == 0) + (coef_res_bits == 3);
+    uint8_t table_index = 2 * (coef_compress != 0) + (coef_res_bits != 3);
     real_t* tns_coef = all_tns_coefs[table_index];
     uint8_t exp = 0;
 


### PR DESCRIPTION
Fixes a logic error introduced in https://github.com/knik0/faad2/commit/713a28e1980ecf381f4c3b961d285caa158955b3#diff-a135d6652db56a2719b24bce7414bab318adcd15a7cfdfcd28deeedf0a7649bbR199-R205

The way the tables are laid out and the index is specified is the inverse of the previous logic. When the values are equal you would want the resulting addition to the table index to be 0, not 1. This inverts the comparisons to bring it back in line with how it was before.

This fixes a regression which was causing high pitched audio artifacts in some decoded AAC frames.