### PR TITLE
Change order of checks

### DIFF
--- a/libfaad/decoder.c
+++ b/libfaad/decoder.c
@@ -837,7 +837,7 @@ void* NeAACDecDecode2(NeAACDecHandle hpDecoder,
                                   unsigned long sample_buffer_size)
 {
     NeAACDecStruct* hDecoder = (NeAACDecStruct*)hpDecoder;
-    if ((sample_buffer == NULL) || (*sample_buffer == NULL) || (sample_buffer_size == 0))
+    if ((sample_buffer_size == 0) || (sample_buffer == NULL) || (*sample_buffer == NULL))
     {
         hInfo->error = 27;
         return NULL;


### PR DESCRIPTION
Basically that is no-op, unless function is called from auto-generated fuzzer. (those does stupid thing: for 0-sized vector it takes .data(); changing order of checks we avoid touching that invalid pointer)