### PR TITLE
CMakeLists: Install files with MSVC

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -268,7 +268,7 @@ if (FAAD_BUILD_CLI)
 endif()
 # Installation
 
-if(NOT FAAD_BUNDLED_MODE AND NOT MSVC)
+if(NOT FAAD_BUNDLED_MODE)
   install(FILES "${CMAKE_CURRENT_BINARY_DIR}/faad2.pc"
     DESTINATION "${CMAKE_INSTALL_LIBDIR}/pkgconfig")
 


### PR DESCRIPTION
I build faad2 with MSVC but it's hard-coded to turn off installation of files for MSVC. If this is still necessary, I suggest to make it a CMake option instead. I also use pkg-config on Windows.