### PR TITLE
Fix gapless calculation in frontend

### DIFF
--- a/frontend/main.c
+++ b/frontend/main.c
@@ -925,7 +925,7 @@ static int decodeMP4file(char *mp4file, char *sndfile, char *adts_fn, int to_std
         decoded += dur;
 
         if (decoded > mp4config.samples)
-            dur += mp4config.samples - decoded;
+            dur -= decoded - mp4config.samples;
 
         if (dur > framesize)
         {


### PR DESCRIPTION
Right side is evaluated first. samples and decoded are unsigned ints which underflow to a very large number.