### PR TITLE
fix build with gcc-15

### DIFF
--- a/libfaad/common.h
+++ b/libfaad/common.h
@@ -255,7 +255,7 @@ typedef float float32_t;
 #  define strchr index
 #  define strrchr rindex
 # endif
-char *strchr(), *strrchr();
+char *strchr(const char *, int), *strrchr(const char *, int);
 # if !HAVE_MEMCPY
 #  define memcpy(d, s, n) bcopy((s), (d), (n))
 #  define memmove(d, s, n) bcopy((s), (d), (n))


### PR DESCRIPTION
Fixes void declarations

```
In file included from ./libfaad/output.c:31:
./libfaad/common.h:244:18: error: conflicting types for 'index'; have 'char *(void)'
  244 | #  define strchr index
      |                  ^~~~~
./libfaad/common.h:247:7: note: in expansion of macro 'strchr'
  247 | char *strchr(), *strrchr();
      |       ^~~~~~
In file included from /usr/include/string.h:462,
                 from ./libfaad/common.h:205:
/usr/include/strings.h:68:14: note: previous declaration of 'index' with type 'char *(const char *, int)'
   68 | extern char *index (const char *__s, int __c)
      |              ^~~~~
./libfaad/common.h:245:19: error: conflicting types for 'rindex'; have 'char *(void)'
  245 | #  define strrchr rindex
      |                   ^~~~~~
./libfaad/libfaad/common.h:247:18: note: in expansion of macro 'strrchr'
  247 | char *strchr(), *strrchr();
      |                  ^~~~~~~
/usr/include/strings.h:96:14: note: previous declaration of 'rindex' with type 'char *(const char *, int)'
   96 | extern char *rindex (const char *__s, int __c)
      |              ^~~~~~
```