### PR TITLE
fix off-by-one frame index check in mp4read_seek

### DIFF
--- a/frontend/mp4read.c
+++ b/frontend/mp4read.c
@@ -1016,7 +1016,7 @@ int mp4read_frame(void)
 
 int mp4read_seek(uint32_t framenum)
 {
-    if (framenum > mp4config.frame.nsamples)
+    if (framenum >= mp4config.frame.nsamples)
         return ERR_FAIL;
     if (fseek(g_fin, mp4config.frame.info[framenum].offset, SEEK_SET))
         return ERR_FAIL;


### PR DESCRIPTION
mp4read_seek treats framenum == nsamples as in range, but frame.info is allocated with only nsamples entries. A -j seek that maps to the frame count reaches mp4read_seek(nsamples) and reads one frame_info_t past the buffer. Reject framenum == nsamples.