### PR TITLE
fix integer overflow in stszin/stscin allocation size checks

### DIFF
--- a/frontend/mp4read.c
+++ b/frontend/mp4read.c
@@ -350,9 +350,9 @@ static int stscin(int size)
     if (!mp4config.frame.nsclices)
         return ERR_FAIL;
 
-    tmp = sizeof(slice_info_t) * mp4config.frame.nsclices;
-    if (tmp < mp4config.frame.nsclices)
+    if (mp4config.frame.nsclices > UINT32_MAX / sizeof(slice_info_t))
         return ERR_FAIL;
+    tmp = sizeof(slice_info_t) * mp4config.frame.nsclices;
     mp4config.frame.map = malloc(tmp);
     if (!mp4config.frame.map)
         return ERR_FAIL;
@@ -396,9 +396,9 @@ static int stszin(int size)
     if (!mp4config.frame.nsamples)
         return ERR_FAIL;
 
-    tmp = sizeof(frame_info_t) * mp4config.frame.nsamples;
-    if (tmp < mp4config.frame.nsamples)
+    if (mp4config.frame.nsamples > UINT32_MAX / sizeof(frame_info_t))
         return ERR_FAIL;
+    tmp = sizeof(frame_info_t) * mp4config.frame.nsamples;
     mp4config.frame.info = malloc(tmp);
     if (!mp4config.frame.info)
         return ERR_FAIL;


### PR DESCRIPTION
stszin() and stscin() guard their table allocations with `if (tmp < count)`, but tmp is a uint32_t holding the truncated low 32 bits of `sizeof(T) * count` (both element types are 8 bytes). For an stsz/stsc entry count like 0x24924925 the product overflows 2^32 while the truncated value stays above count, so the check passes, malloc gets an undersized buffer, and the following fill loop writes every entry past it. A crafted MP4 reaches both sites. Test the count against UINT32_MAX/sizeof before multiplying.