### PR TITLE
bound sscanf field width in option parsing

### DIFF
--- a/frontend/main.c
+++ b/frontend/main.c
@@ -1114,7 +1114,7 @@ static int faad_main(int argc, char *argv[])
             if (optarg)
             {
                 char dr[10];
-                if (sscanf(optarg, "%s", dr) < 1) {
+                if (sscanf(optarg, "%9s", dr) < 1) {
                     def_srate = 0;
                 } else {
                     def_srate = atoi(dr);
@@ -1125,7 +1125,7 @@ static int faad_main(int argc, char *argv[])
             if (optarg)
             {
                 char dr[10];
-                if (sscanf(optarg, "%s", dr) < 1)
+                if (sscanf(optarg, "%9s", dr) < 1)
                 {
                     format = 1;
                 } else {
@@ -1139,7 +1139,7 @@ static int faad_main(int argc, char *argv[])
             if (optarg)
             {
                 char dr[10];
-                if (sscanf(optarg, "%s", dr) < 1)
+                if (sscanf(optarg, "%9s", dr) < 1)
                 {
                     outputFormat = FAAD_FMT_16BIT; /* just use default */
                 } else {
@@ -1156,7 +1156,7 @@ static int faad_main(int argc, char *argv[])
             if (optarg)
             {
                 char dr[10];
-                if (sscanf(optarg, "%s", dr) < 1)
+                if (sscanf(optarg, "%9s", dr) < 1)
                 {
                     object_type = LC; /* default */
                 } else {


### PR DESCRIPTION
1. the -s, -f, -b and -l handlers read optarg into a 10 byte stack buffer with sscanf(optarg, "%s", dr), which sets no field width.
2. an argument longer than 9 characters writes past dr and corrupts the stack.

Changed all four conversions to %9s so at most 9 characters plus the terminator land in dr; the following atoi() keeps its current behavior.

Validation: compiled with -fstack-protector and ran `faad -s 11111111111111111111 in.aac`. Before the change it aborts with "stack smashing detected"; after it parses the value normally.