### PR TITLE
fix out-of-bounds iq_table read in iquant for -32768

### DIFF
--- a/libfaad/specrec.c
+++ b/libfaad/specrec.c
@@ -444,34 +444,38 @@ static INLINE real_t iquant(int16_t q, const real_t *tab, uint8_t *error)
     real_t x1, x2;
 #endif
     int16_t sgn = 1;
+    /* compute the magnitude in int: -q is evaluated as int and so does not
+       wrap for q == -32768 the way an int16_t negation would, which keeps the
+       comparison against IQ_TABLE_SIZE in range like the floating-point path */
+    int aq = q;
 
-    if (q < 0)
+    if (aq < 0)
     {
-        q = -q;
+        aq = -aq;
         sgn = -1;
     }
 
-    if (q < IQ_TABLE_SIZE)
+    if (aq < IQ_TABLE_SIZE)
     {
 //#define IQUANT_PRINT
 #ifdef IQUANT_PRINT
-        //printf("0x%.8X\n", sgn * tab[q]);
-        printf("%d\n", sgn * tab[q]);
+        //printf("0x%.8X\n", sgn * tab[aq]);
+        printf("%d\n", sgn * tab[aq]);
 #endif
-        return sgn * tab[q];
+        return sgn * tab[aq];
     }
 
 #ifndef BIG_IQ_TABLE
-    if (q >= 8192)
+    if (aq >= 8192)
     {
         *error = 17;
         return 0;
     }
 
     /* linear interpolation */
-    x1 = tab[q>>3];
-    x2 = tab[(q>>3) + 1];
-    return sgn * 16 * (MUL_R(errcorr[q&7],(x2-x1)) + x1);
+    x1 = tab[aq>>3];
+    x2 = tab[(aq>>3) + 1];
+    return sgn * 16 * (MUL_R(errcorr[aq&7],(x2-x1)) + x1);
 #else
     *error = 17;
     return 0;


### PR DESCRIPTION
1. huffman_getescape() can yield a quantized value of -32768: an escape with i==15 and off==0 computes off | (1<<15) = 32768, which overflows int16_t. ESC_HCB (cb 11) carries no LAV clamp, so the value lands verbatim in the spectral buffer and is later read by quant_to_spec().
2. in the fixed-point build iquant() negates it with `q = -q`, but -(-32768) is not representable as int16_t, so q stays -32768; the following `q < IQ_TABLE_SIZE` test then passes and iq_table[-32768] is read out of bounds. The floating-point path range-checks `-q` in int before indexing and is unaffected.
3. reject q == -32768 before the negation and return the out-of-range error, matching the floating-point path.