### PR TITLE
prevent length_of_rvlc_sf underflow in rvlc_scale_factor_data

### DIFF
--- a/libfaad/rvlc.c
+++ b/libfaad/rvlc.c
@@ -92,6 +92,12 @@ uint8_t rvlc_scale_factor_data(ic_stream *ics, bitfile *ld)
         ics->dpcm_noise_nrg = (uint16_t)faad_getbits(ld, 9
             DEBUGVAR(1,152,"rvlc_scale_factor_data(): dpcm_noise_nrg"));
 
+        /* the 9 bits of dpcm_noise_nrg are counted in length_of_rvlc_sf, so a
+           conformant value is at least 9; reject a smaller one before the
+           unsigned subtraction wraps length_of_rvlc_sf to a huge value */
+        if (ics->length_of_rvlc_sf < 9)
+            return 8;
+
         ics->length_of_rvlc_sf -= 9;
     }
 


### PR DESCRIPTION
1. rvlc_scale_factor_data() in libfaad/rvlc.c reads length_of_rvlc_sf as a 9- or 11-bit bitstream field, then subtracts 9 (the dpcm_noise_nrg bits) from it when noise_used is set.
2. length_of_rvlc_sf is uint16_t, so a crafted field below 9 makes the subtraction wrap to ~65532; rvlc_decode_scale_factors then passes that to faad_getbitbuffer, which allocates and pulls that many bits out of the frame.
Added a check that rejects length_of_rvlc_sf < 9 before the subtraction and returns error 8, matching the existing ER scalefactor error handling.

Verified with a small harness calling rvlc_scale_factor_data on a stream whose length_of_rvlc_sf field is 5 with noise_used set: before, length_of_rvlc_sf becomes 65532 and parsing continues; after, the call returns 8 and the value is left untouched.