### PR TITLE
fix out-of-bounds Xsbr write in hf_assembly sinusoid addition

### DIFF
--- a/libfaad/sbr_hfadj.c
+++ b/libfaad/sbr_hfadj.c
@@ -1713,7 +1713,7 @@ static void hf_assembly(sbr_info *sbr, sbr_hfadj_info *adj,
                             QMF_RE(Xsbr[i + sbr->tHFAdj][m+sbr->kx]) -=
                                 (rev*phi_re[i_min1] * MUL_F(adj->S_M_boost[l][m - 1], FRAC_CONST(0.00815)));
                         }
-                        if (m + sbr->kx < 64)
+                        if (m + sbr->kx + 1 < 64)
                         {
                             QMF_RE(Xsbr[i + sbr->tHFAdj][m+sbr->kx + 1]) +=
                                 (rev*phi_re[i_min1] * MUL_F(adj->S_M_boost[l][m], FRAC_CONST(0.00815)));


### PR DESCRIPTION
hf_assembly guards the top-band sinusoid leak with `if (m + sbr->kx < 64)` but writes Xsbr[i + tHFAdj][m + sbr->kx + 1], so when a crafted SBR header makes kx + M reach 64 (the largest value derived_frequency_table allows) the m == M-1 step has m + kx of 63, passes the check, and writes one QMF subband past the 64-wide Xsbr row into the next time slot of the history buffer. The faulty write sits in the SBR_LOW_POWER synthesis path and triggers on a crafted HE-AAC stream whose frequency band layout reaches that boundary. Comparing the index that is actually written keeps the leaked top-band energy from landing out of range.