### PR TITLE
fix out-of-bounds X underflow in SBR low-power QMF assembly

### DIFF
--- a/libfaad/sbr_dec.c
+++ b/libfaad/sbr_dec.c
@@ -444,8 +444,14 @@ static uint8_t sbr_process_channel(sbr_info *sbr, real_t *channel_buf, qmf_t X[M
             {
                 QMF_RE(X[l][k]) = 0;
             }
-            QMF_RE(X[l][kx_band - 1 + bsco_band]) +=
-                QMF_RE(sbr->Xsbr[ch][l + sbr->tHFAdj][kx_band - 1 + bsco_band]);
+            /* kx_band can be 0 (kx_prev on the first frame's leading slots),
+               which would make kx_band - 1 + bsco_band index X[l][-1]. There is
+               no band below 0 to add in that case, so skip the overlap. */
+            if (kx_band + bsco_band > 0)
+            {
+                QMF_RE(X[l][kx_band - 1 + bsco_band]) +=
+                    QMF_RE(sbr->Xsbr[ch][l + sbr->tHFAdj][kx_band - 1 + bsco_band]);
+            }
 #endif
         }
     }


### PR DESCRIPTION
1. In `SBR_LOW_POWER` builds, `sbr_process_channel()` (libfaad/sbr_dec.c) finishes each output time slot of the QMF matrix `X` with an overlap add:

   ```c
   QMF_RE(X[l][kx_band - 1 + bsco_band]) +=
       QMF_RE(sbr->Xsbr[ch][l + sbr->tHFAdj][kx_band - 1 + bsco_band]);
   ```

2. For the leading time slots (`l < sbr->t_E[ch][0]`) the band parameters are taken from the previous frame: `kx_band = sbr->kx_prev` and `bsco_band = sbr->bsco_prev`.

3. On the very first decoded SBR frame both are still `0`: `sbr_info` is zero-initialised, and `sbr_save_prev_data()` — the only writer of `kx_prev`/`bsco_prev` — runs *after* the frame is processed.

4. A first frame whose grid is `VARFIX` or `VARVAR` with `bs_abs_bord >= 1` sets `abs_bord_lead > 0`, so `t_E[ch][0] = rate * abs_bord_lead > 0`. The `l = 0` slot then takes the `kx_prev` path, and `kx_band - 1 + bsco_band` evaluates to `-1`, so the statement reads and writes `X[0][-1]` — one `real_t` before the stack array `X[MAX_NTSRHFG][64]`. AddressSanitizer reports a stack-buffer-underflow at sbr_dec.c:447.

5. The current-frame `kx` is always `>= 5` (the `qmf_start_channel()` start tables and `derived_frequency_table()`), so the only way `kx_band + bsco_band` can be `0` is the first-frame `kx_prev == 0` / `bsco_prev == 0` case. This is a different site from the `hf_assembly()` upper-bound (`m + kx + 1 == 64`) overflow.

6. Fix: guard the overlap add with `if (kx_band + bsco_band > 0)`, skipping it when there is no band below `0` to add. Normal frames (`kx_band >= 5`) are unaffected and the high-quality (non-low-power) path does not contain this statement.

7. Verified with a minimal crafted SBR payload driven through `sbr_extension_data()` + `sbrDecodeSingleFrame()` in an `SBR_LOW_POWER` + ASan build: stack-buffer-underflow at sbr_dec.c:447 before the change, clean afterwards (`ret == 0`, decode continues). The default and `SBR_LOW_POWER` configurations both build clean with `-Wall`.
