### PR TITLE
fix ssr_gc_function signature mismatch in ssr gain control

### DIFF
--- a/libfaad/ssr.c
+++ b/libfaad/ssr.c
@@ -37,6 +37,7 @@
 #include "filtbank.h"
 #include "ssr.h"
 #include "ssr_fb.h"
+#include "ssr_ipqf.h"
 
 void ssr_decode(ssr_info *ssr, fb_info *fb, uint8_t window_sequence,
                 uint8_t window_shape, uint8_t window_shape_prev,
@@ -90,7 +91,7 @@ static void ssr_gain_control(ssr_info *ssr, real_t *data, real_t *output,
     if (window_sequence != EIGHT_SHORT_SEQUENCE)
     {
         ssr_gc_function(ssr, &prev_fmd[band * frame_len*2],
-            gc_function, window_sequence, band, frame_len);
+            gc_function, window_sequence, frame_len);
 
         for (i = 0; i < frame_len*2; i++)
             data[band * frame_len*2 + i] *= gc_function[i];
@@ -136,7 +137,7 @@ static void ssr_gain_control(ssr_info *ssr, real_t *data, real_t *output,
 
 static void ssr_gc_function(ssr_info *ssr, real_t *prev_fmd,
                             real_t *gc_function, uint8_t window_sequence,
-                            uint8_t band, uint16_t frame_len)
+                            uint16_t frame_len)
 {
     uint16_t i;
     uint16_t len_area1, len_area2;

--- a/libfaad/ssr.c
+++ b/libfaad/ssr.c
@@ -39,6 +39,10 @@
 #include "ssr_fb.h"
 #include "ssr_ipqf.h"
 
+static void ssr_gc_function(ssr_info *ssr, real_t *prev_fmd,
+                            real_t *gc_function, uint8_t window_sequence,
+                            uint16_t frame_len);
+
 void ssr_decode(ssr_info *ssr, fb_info *fb, uint8_t window_sequence,
                 uint8_t window_shape, uint8_t window_shape_prev,
                 real_t *freq_in, real_t *time_out, real_t *overlap,


### PR DESCRIPTION
1. ssr_gc_function is declared in ssr.h with five parameters but defined in ssr.c with a sixth `band` parameter, and the two calls in ssr_gain_control() disagree: the long-window path passes six arguments while the eight-short path passes five.
2. with SSR_DEC enabled this does not compile (conflicting types for ssr_gc_function, and too many arguments at the long-window call), and `band` is never read in the function body.
3. ssr_decode() also calls ssr_ipqf() without including ssr_ipqf.h, a second compile error on the same path.

Removed the unused `band` parameter so the definition and both calls match the declaration, and added the missing ssr_ipqf.h include. ssr.c is compiled only under SSR_DEC, so the default build is unchanged.