### PR TITLE
fix signed overflow in estimate_current_envelope energy sum

### DIFF
--- a/libfaad/sbr_hfadj.c
+++ b/libfaad/sbr_hfadj.c
@@ -138,13 +138,19 @@ static uint8_t estimate_current_envelope(sbr_info *sbr, sbr_hfadj_info *adj,
                                          qmf_t Xsbr[MAX_NTSRHFG][64], uint8_t ch)
 {
     uint8_t m, l, j, k, k_l, k_h, p;
-    real_t nrg, div;
+    real_t div;
     (void)adj;  /* TODO: remove parameter? */
 #ifdef FIXED_POINT
+    /* the per-bin energy is accumulated over the envelope's time slots and,
+       for the wider bands, its QMF bins; that sum exceeds 32 bits on ordinary
+       content, so keep it in 64 bits. the running int32 sum otherwise wraps
+       before the limit test below can reject an over-range energy. */
+    int64_t nrg;
     const real_t half = REAL_CONST(0.5);
     real_t limit;
     real_t mul;
 #else
+    real_t nrg;
     const real_t half = 0;  /* Compiler is smart enough to eliminate +0 op. */
     const real_t limit = FLT_MAX;
 #endif


### PR DESCRIPTION
1. estimate_current_envelope() sums the per-band QMF energy into `nrg`, a 32-bit real_t, over the envelope's time slots and (in the second loop) its QMF bins. On ordinary HE-AAC/HE-AACv2 content this running sum passes INT32_MAX and the signed addition overflows.
2. The `if (nrg < -limit || nrg > limit) return 1` guard right after is meant to reject over-range energies, but it reads the already-wrapped value, so it only rejects sums that happen to land negative; one that wraps back into range is accepted and a corrupt E_curr goes to the limiter.

Widened `nrg` to int64_t in the fixed-point build so the accumulation and the limit test are evaluated in range. Both loops share the variable, so both are covered. The float build is untouched and valid fixed-point decode output is byte-identical; a UBSan build reported signed-integer-overflow at this line on a normal HE-AAC stream and is clean after the change.