### PR TITLE
cap escape length in huffman_spectral_data_2

### DIFF
--- a/libfaad/huffman.c
+++ b/libfaad/huffman.c
@@ -561,7 +561,7 @@ int8_t huffman_spectral_data_2(uint8_t cb, bits_t *ld, int16_t *sp)
 
                 neg = (sp[k] < 0) ? 1 : 0;
 
-                for (i = 4; ; i++)
+                for (i = 4; i < 16; i++)
                 {
                     uint8_t b;
                     if (get1bit_hcr(ld, &b))
@@ -570,7 +570,7 @@ int8_t huffman_spectral_data_2(uint8_t cb, bits_t *ld, int16_t *sp)
                         break;
                 }
 
-                if (i > 32)
+                if (i >= 16)
                     return -1;
 
                 if (getbits_hcr(ld, i, &off))


### PR DESCRIPTION
1. huffman_spectral_data_2 reads the ER/HCR spectral escape with an unbounded length loop, for (i = 4; ; i++), rejected only at i > 32.
2. the standard escape decoder huffman_getescape in the same file caps the length at i < 16 and returns an error for i >= 16, so an over-long escape prefix is accepted here where the standard path rejects it.
3. the wide bound also permits j = off + (1 << i) to shift by up to 32 bits, out of range for the int expression.

Capped the loop at i < 16 and reject i >= 16, matching huffman_getescape. Escapes of length 15 or less, i.e. all well-formed streams, decode unchanged.
