### PR TITLE
fix signed overflow in fixed-point sample rounding before saturation

### DIFF
--- a/libfaad/lt_predict.c
+++ b/libfaad/lt_predict.c
@@ -137,11 +137,13 @@ static INLINE int16_t real_to_int16(real_t sig_in)
 {
     if (sig_in >= 0)
     {
-        sig_in += (1 << (REAL_BITS-1));
+        if (sig_in <= 0x7FFFFFFF - (1 << (REAL_BITS-1)))
+            sig_in += (1 << (REAL_BITS-1));
         if (sig_in >= REAL_CONST(32768))
             return 32767;
     } else {
-        sig_in += -(1 << (REAL_BITS-1));
+        if (sig_in >= (int32_t)0x80000000 + (1 << (REAL_BITS-1)))
+            sig_in += -(1 << (REAL_BITS-1));
         if (sig_in <= REAL_CONST(-32768))
             return -32768;
     }

--- a/libfaad/output.c
+++ b/libfaad/output.c
@@ -488,13 +488,15 @@ void* output_to_PCM(NeAACDecStruct *hDecoder,
                     hDecoder->internal_channel);
                 if (tmp >= 0)
                 {
-                    tmp += (1 << (REAL_BITS-1));
+                    if (tmp <= 0x7FFFFFFF - (1 << (REAL_BITS-1)))
+                        tmp += (1 << (REAL_BITS-1));
                     if (tmp >= REAL_CONST(32767))
                     {
                         tmp = REAL_CONST(32767);
                     }
                 } else {
-                    tmp += -(1 << (REAL_BITS-1));
+                    if (tmp >= (int32_t)0x80000000 + (1 << (REAL_BITS-1)))
+                        tmp += -(1 << (REAL_BITS-1));
                     if (tmp <= REAL_CONST(-32768))
                     {
                         tmp = REAL_CONST(-32768);
@@ -511,14 +513,16 @@ void* output_to_PCM(NeAACDecStruct *hDecoder,
                     hDecoder->internal_channel);
                 if (tmp >= 0)
                 {
-                    tmp += (1 << (REAL_BITS-9));
+                    if (tmp <= 0x7FFFFFFF - (1 << (REAL_BITS-9)))
+                        tmp += (1 << (REAL_BITS-9));
                     tmp >>= (REAL_BITS-8);
                     if (tmp >= 8388607)
                     {
                         tmp = 8388607;
                     }
                 } else {
-                    tmp += -(1 << (REAL_BITS-9));
+                    if (tmp >= (int32_t)0x80000000 + (1 << (REAL_BITS-9)))
+                        tmp += -(1 << (REAL_BITS-9));
                     tmp >>= (REAL_BITS-8);
                     if (tmp <= -8388608)
                     {
@@ -538,9 +542,11 @@ void* output_to_PCM(NeAACDecStruct *hDecoder,
                     hDecoder->internal_channel);
                 if (tmp >= 0)
                 {
-                    tmp += half;
+                    if (tmp <= 0x7FFFFFFF - half)
+                        tmp += half;
                 } else {
-                    tmp += -half;
+                    if (tmp >= (int32_t)0x80000000 + half)
+                        tmp += -half;
                 }
                 tmp = SAT_SHIFT(tmp, exp, sat_shift_mask);
                 int_sample_buffer[(i*channels)+ch] = tmp;


### PR DESCRIPTION
1. In the fixed-point build, output_to_PCM (libfaad/output.c) and real_to_int16 (libfaad/lt_predict.c) add a rounding bias to the raw int32 sample before the saturation clamp, so a decoded sample near INT32_MAX/INT32_MIN overflows the signed addition and the wrapped value then skips the clamp, emitting a garbage sample instead of the saturated one. UBSan on an HE-AAC stream: signed-integer-overflow at output.c:491 (2147483384 + 8192) and lt_predict.c:140.
2. The same rounding-before-saturation pattern is present in the 16-, 24- and 32-bit output_to_PCM cases and in real_to_int16.
3. Apply the rounding bias only when it cannot overflow the int32; a value large enough to overflow saturates anyway, so valid output is unchanged. Verified byte-identical 16/24/32-bit output on LC, HE-AAC and HE-AACv2 streams, and the CMake build stays clean with -Werror=strict-aliasing. Float build is unaffected.