### PR TITLE
fix null pointer dereferences in intra channel and long term prediction

### DIFF
--- a/libfaad/error.c
+++ b/libfaad/error.c
@@ -65,6 +65,6 @@ char *err_msg[] = {
     "No standard extension payload allowed in DRM",
     "PCE shall be the first element in a frame",
     "Bitstream value not allowed by specification",
-	"MAIN prediction not initialised"
+    "MAIN prediction not initialised",
+    "Long term prediction not initialised"
 };
-

--- a/libfaad/error.h
+++ b/libfaad/error.h
@@ -35,7 +35,7 @@
 extern "C" {
 #endif
 
-#define NUM_ERROR_MESSAGES 34
+#define NUM_ERROR_MESSAGES 35
 extern char *err_msg[];
 
 #ifdef __cplusplus

--- a/libfaad/specrec.c
+++ b/libfaad/specrec.c
@@ -996,8 +996,8 @@ uint8_t reconstruct_single_channel(NeAACDecStruct *hDecoder, ic_stream *ics,
     /* MAIN object type prediction */
     if (hDecoder->object_type == MAIN)
     {
-		if (!hDecoder->pred_stat[sce->channel])
-			return 33;
+        if (!hDecoder->pred_stat[sce->channel])
+            return 33;
 
         /* intra channel prediction */
         ic_prediction(ics, spec_coef, hDecoder->pred_stat[sce->channel], hDecoder->frameLength,
@@ -1230,6 +1230,9 @@ uint8_t reconstruct_channel_pair(NeAACDecStruct *hDecoder, ic_stream *ics1, ic_s
     /* MAIN object type prediction */
     if (hDecoder->object_type == MAIN)
     {
+        if (!hDecoder->pred_stat[cpe->channel] || !hDecoder->pred_stat[cpe->paired_channel])
+            return 33;
+
         /* intra channel prediction */
         ic_prediction(ics1, spec_coef1, hDecoder->pred_stat[cpe->channel], hDecoder->frameLength,
             hDecoder->sf_index);

--- a/libfaad/specrec.c
+++ b/libfaad/specrec.c
@@ -1026,6 +1026,9 @@ uint8_t reconstruct_single_channel(NeAACDecStruct *hDecoder, ic_stream *ics,
         }
 #endif
 
+        if (!hDecoder->lt_pred_stat[sce->channel])
+            return 34;
+
         /* long term prediction */
         lt_prediction(ics, &(ics->ltp), spec_coef, hDecoder->lt_pred_stat[sce->channel], hDecoder->fb,
             ics->window_shape, hDecoder->window_shape_prev[sce->channel],
@@ -1270,6 +1273,9 @@ uint8_t reconstruct_channel_pair(NeAACDecStruct *hDecoder, ic_stream *ics1, ic_s
             ltp2->lag = hDecoder->ltp_lag[cpe->paired_channel];
         }
 #endif
+
+        if (!hDecoder->lt_pred_stat[cpe->channel] || !hDecoder->lt_pred_stat[cpe->paired_channel])
+            return 34;
 
         /* long term prediction */
         lt_prediction(ics1, ltp1, spec_coef1, hDecoder->lt_pred_stat[cpe->channel], hDecoder->fb,


### PR DESCRIPTION
I have experienced random segfaults when playing AAC files from https://toolsfairy.com/audio-test/sample-aac-files with [Audacious](https://audacious-media-player.org). Its AAC plugin is based on faad2 and while debugging this, I found out the underlying problems are null pointer dereferences in faad2. The two commits prevent the segfaults by appropriate null checks.