### PR TITLE
Fix the fixed-point SBR envelope estimate

### DIFF
--- a/libfaad/sbr_hfadj.c
+++ b/libfaad/sbr_hfadj.c
@@ -147,8 +147,7 @@ static uint8_t estimate_current_envelope(sbr_info *sbr, sbr_hfadj_info *adj,
        before the limit test below can reject an over-range energy. */
     int64_t nrg;
     const real_t half = REAL_CONST(0.5);
-    real_t limit;
-    real_t mul;
+    int64_t limit;
 #else
     real_t nrg;
     const real_t half = 0;  /* Compiler is smart enough to eliminate +0 op. */
@@ -169,8 +168,7 @@ static uint8_t estimate_current_envelope(sbr_info *sbr, sbr_hfadj_info *adj,
             if (div <= 0)
                 div = 1;
 #ifdef FIXED_POINT
-            limit = div << (30 - (COEF_BITS - REAL_BITS));
-            mul = (1 << (COEF_BITS - REAL_BITS)) / div;
+            limit = (int64_t)div << 30;
 #endif
 
             for (m = 0; m < sbr->M; m++)
@@ -196,7 +194,7 @@ static uint8_t estimate_current_envelope(sbr_info *sbr, sbr_hfadj_info *adj,
                 if (nrg < -limit || nrg > limit)
                     return 1;
 #ifdef FIXED_POINT
-                sbr->E_curr[ch][m][l] = nrg * mul;
+                sbr->E_curr[ch][m][l] = (real_t)(nrg / div);
 #else
                 sbr->E_curr[ch][m][l] = nrg / div;
 #endif
@@ -230,8 +228,7 @@ static uint8_t estimate_current_envelope(sbr_info *sbr, sbr_hfadj_info *adj,
                     if (div <= 0)
                         div = 1;
 #ifdef FIXED_POINT
-                    limit = div << (30 - (COEF_BITS - REAL_BITS));
-                    mul = (1 << (COEF_BITS - REAL_BITS)) / div;
+                    limit = (int64_t)div << 30;
 #endif
 
                     for (i = l_i + sbr->tHFAdj; i < u_i + sbr->tHFAdj; i++)
@@ -256,7 +253,7 @@ static uint8_t estimate_current_envelope(sbr_info *sbr, sbr_hfadj_info *adj,
                     if (nrg < -limit || nrg > limit)
                         return 1;
 #ifdef FIXED_POINT
-                    sbr->E_curr[ch][k - sbr->kx][l] = nrg * mul;
+                    sbr->E_curr[ch][k - sbr->kx][l] = (real_t)(nrg / div);
 #else
                     sbr->E_curr[ch][k - sbr->kx][l] = nrg / div;
 #endif


### PR DESCRIPTION
Since 2.11.0 the fixed-point build decodes HE-AAC poorly. The lowest SBR bands come out too loud and the rest of the high band is mostly missing. A bisect between 2.10.1 and 2.11.0, comparing the fixed-point and float builds band by band, points at c7947ad ("Fix integer overflow in estimate_envelope", #178).

1. `calculate_gain()` expects `E_curr` to be a plain integer. It takes `log2_int()` of it and compares that with `find_log2_E()`, and a comment in `aliasing_reduction()` says the same (`E_curr: integer`).
2. Squaring with `MUL_C` already gives a plain integer. `mul` then scales the result up by 2^14 to undo a prescale that never happened, so `E_curr` comes out 2^14 too large and every gain too small.
3. `limit` is on that same scale, so it rejects envelopes at ordinary loudness, and when that happens `sbr_process_channel()` outputs the frame unadjusted.

fd16df1 (#227) later made `nrg` 64-bit but kept `mul` and `limit`.

This makes `limit` 64-bit too, sets it so the stored value fits in `real_t`, and stores `nrg / div` as the code did before. The overflow fix stays intact.

Verified against [al_sbr_cm_48_2.mp4](https://fate-suite.ffmpeg.org/aac/al_sbr_cm_48_2.mp4), where the fixed-point output now matches the float build, and on a WM8505 (ARM926EJ-S, no FPU) playing a live HE-AAC stream, which is how this was noticed. A UBSan build reports no runtime errors.