### PR TITLE
pns: fix decoding window offset clamping for short sequences

### DIFF
--- a/libfaad/pns.c
+++ b/libfaad/pns.c
@@ -203,8 +203,10 @@ void pns_decode(ic_stream *ics_left, ic_stream *ics_right,
                     */
                     ics_left->pred.prediction_used[sfb] = 0;
 #endif
-                    begin = min(base + ics_left->swb_offset[sfb], ics_left->swb_offset_max);
-                    end = min(base + ics_left->swb_offset[sfb+1], ics_left->swb_offset_max);
+                    /* swb_offset_max is per-window, not per-frame; clamping
+                       group>0 offsets against it zeroed out begin/end. */
+                    begin = min(base + ics_left->swb_offset[sfb], frame_len);
+                    end = min(base + ics_left->swb_offset[sfb+1], frame_len);
 
                     r1_dep = *__r1;
                     r2_dep = *__r2;
@@ -247,16 +249,16 @@ void pns_decode(ic_stream *ics_left, ic_stream *ics_right,
                     {
                         /*uint16_t c;*/
 
-                        begin = min(base + ics_right->swb_offset[sfb], ics_right->swb_offset_max);
-                        end = min(base + ics_right->swb_offset[sfb+1], ics_right->swb_offset_max);
+                        begin = min(base + ics_right->swb_offset[sfb], frame_len);
+                        end = min(base + ics_right->swb_offset[sfb+1], frame_len);
 
                         /* Generate random vector dependent on left channel*/
                         gen_rand_vector(&spec_right[begin],
                             ics_right->scale_factors[g][sfb], end - begin, sub, &r1_dep, &r2_dep);
 
                     } else /*if (ics_left->ms_mask_present == 0)*/ {
-                        begin = min(base + ics_right->swb_offset[sfb], ics_right->swb_offset_max);
-                        end = min(base + ics_right->swb_offset[sfb+1], ics_right->swb_offset_max);
+                        begin = min(base + ics_right->swb_offset[sfb], frame_len);
+                        end = min(base + ics_right->swb_offset[sfb+1], frame_len);
 
                         /* Generate random vector */
                         gen_rand_vector(&spec_right[begin],


### PR DESCRIPTION
Fixes a bug in `pns_decode()` where Perceptual Noise Substitution (PNS) band bounds (`begin`/`end`) were incorrectly clamped against `ics->swb_offset_max` instead of the full buffer size (`frame_len`).

For `EIGHT_SHORT_SEQUENCE` frames, `swb_offset_max` spans only a single short window (`frame_len / 8`). As a result, `base = group * nshort` evaluated to `>= swb_offset_max` for every window group after the first. Clamping against `swb_offset_max` caused `min(base + swb_offset[sfb], swb_offset_max)` to collapse to `swb_offset_max`, resulting in `begin == end` and silently skipping PNS noise generation across 7 of the 8 window groups in short frames.

**Fix:** Clamp band offsets against `frame_len` (already passed into `pns_decode()`) to reflect the actual bounds of the spectral array.

Fixes #191

---

### Verification & Benchmark Results

Tested on a low-bitrate FAAC-encoded AAC-LC stream (32kbps, PNS enabled, using short-window block switching):

| Metric | faad2 (before) | faad2 (after) | ffmpeg (ref) | Apple `afconvert` (ref) |
|---|---|---|---|---|
| **>8kHz Energy Ratio vs. Source** | 1.52x | **3.57x** | 3.57x | 3.48x |
| **Zimtohrli MOS** | 4.0887 | **4.5640** | 4.5519 | 4.5644 |

- **Decoder parity:** After the fix, high-frequency energy alignment and perceptual quality (MOS) match reference decoders (`ffmpeg` and Apple `afconvert`).
- **Control check:** Disabling PNS (`--pns 0`) yields identical PCM output between `faad2` and `ffmpeg`.
- **Regressions:** Gapless sample counting across the regression test suite remains unaffected.

---

### Test Plan
- [x] Build succeeds clean with CMake/Ninja.
- [x] Verified high-frequency noise spectral energy matches reference implementations.
- [x] Verified Zimtohrli MOS improvement on PNS-heavy short-window test streams.
- [x] Verified existing regression suite passes without sample count drift.